### PR TITLE
#44 Prevent user from clicking Mod Info without selecting a mod first

### DIFF
--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -193,6 +193,11 @@ namespace ModAssistant
 
         private void InfoButton_Click(object sender, RoutedEventArgs e)
         {
+            if ((Mods.ModListItem)Mods.Instance.ModsListView.SelectedItem == null)
+            {
+                MessageBox.Show("No mod selected");
+                return;
+            }
             Mods.ModListItem mod = ((Mods.ModListItem)Mods.Instance.ModsListView.SelectedItem);
             string infoUrl = mod.ModInfo.link;
             if (String.IsNullOrEmpty(infoUrl))

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -52,6 +52,7 @@ namespace ModAssistant.Pages
         {
             MainWindow.Instance.InstallButton.IsEnabled = false;
             MainWindow.Instance.GameVersionsBox.IsEnabled = false;
+            MainWindow.Instance.InfoButton.IsEnabled = false;
 
             if (ModsList != null)
                 Array.Clear(ModsList, 0, ModsList.Length);
@@ -523,7 +524,14 @@ namespace ModAssistant.Pages
 
         private void ModsListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            MainWindow.Instance.InfoButton.IsEnabled = true;
+            if ((Mods.ModListItem)Mods.Instance.ModsListView.SelectedItem == null)
+            {
+                MainWindow.Instance.InfoButton.IsEnabled = false;
+            }
+            else
+            {
+                MainWindow.Instance.InfoButton.IsEnabled = true;
+            }
         }
 
         private void UninstallBSIPA(Mod.DownloadLink links)


### PR DESCRIPTION
Fixed issue #44.