### PR TITLE
Replace version string '1.3.0' with '1.4.2'

### DIFF
--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -79,8 +79,10 @@ namespace ModAssistant
 
                 GameVersion = GetGameVersion(versions);
 
+                versions[versions.FindIndex(e => e.Equals("1.3.0"))] = "1.4.2";
+
                 GameVersionsBox.ItemsSource = versions;
-                GameVersionsBox.SelectedValue = GameVersion;
+                GameVersionsBox.SelectedValue = GameVersion == "1.3.0" ? "1.4.2" : GameVersion;
             }
             catch (Exception e)
             {
@@ -215,6 +217,9 @@ namespace ModAssistant
             string oldGameVersion = GameVersion;
             
             GameVersion = (sender as ComboBox).SelectedItem.ToString();
+
+            if (GameVersion == "1.4.2")
+                GameVersion = "1.3.0";
             
             if (String.IsNullOrEmpty(oldGameVersion)) return;
 


### PR DESCRIPTION
Display the latest mods as version *1.4.2* to prevent confusion and repeated questions about updated mods.