### PR TITLE
WIP - Small bug fixes

### DIFF
--- a/ModAssistant/App.xaml.cs
+++ b/ModAssistant/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -23,9 +24,11 @@ namespace ModAssistant
         public static string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         public static List<string> SavedMods = ModAssistant.Properties.Settings.Default.SavedMods.Split(',').ToList();
 
-
+        
         private void Application_Startup(object sender, StartupEventArgs e)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             if (ModAssistant.Properties.Settings.Default.UpgradeRequired)
             {
                 ModAssistant.Properties.Settings.Default.Upgrade();

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -71,7 +71,7 @@ namespace ModAssistant.Pages
                 await Task.Run(() => CheckInstalledMods());
                 InstalledColumn.Width = Double.NaN;
                 UninstallColumn.Width = 70;
-                DescriptionColumn.Width = 750;
+                DescriptionColumn.Width = 730;
             } else
             {
                 InstalledColumn.Width = 0;


### PR DESCRIPTION
First of all I implemented the suggestion of #67 which is `ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12`. All it does is specifying the TLS version - the bugs could disappear with a a hardcoded TLS version (it should be supported by each win version >= 7).

Second one is to minor to create an issue.
The horizontal scrollbar of the DataGrid was visible because of a miscalculation of 20 px.

### ToDo
- [ ] Try to find a solution for the column with problem (auto adjust)