### PR TITLE
Quick fix for incorrect mods showing as "installed"

### DIFF
--- a/ModAssistant/Classes/Mod.cs
+++ b/ModAssistant/Classes/Mod.cs
@@ -10,6 +10,7 @@ namespace ModAssistant
         public string version;
         public string gameVersion;
         public string _id;
+        public string status;
         public string authorId;
         public string uploadedDate;
         public string updatedDate;

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -133,7 +133,7 @@
     <sys:String x:Key="Options:SelectFolderButton">Select Folder</sys:String>
     <sys:String x:Key="Options:OpenFolderButton">Open Folder</sys:String>
     <sys:String x:Key="Options:SaveSelectedMods">Save Selected Mods</sys:String>
-    <sys:String x:Key="Options:CheckInstalledMods">Check Installed Mods</sys:String>
+    <sys:String x:Key="Options:CheckInstalledMods">Detect Installed Mods</sys:String>
     <sys:String x:Key="Options:SelectInstalledMods">Select Installed Mods</sys:String>
     <sys:String x:Key="Options:EnableOneClickInstalls">Enable OneClick™ Installs</sys:String>
     <sys:String x:Key="Options:BeatSaver">BeatSaver</sys:String>

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -222,7 +222,7 @@ namespace ModAssistant.Pages
         {
             foreach (Mod mod in AllModsList)
             {
-                if (mod.name.ToLower() != "bsipa")
+                if (mod.name.ToLower() != "bsipa" && mod.status != "declined")
                 {
                     foreach (Mod.DownloadLink download in mod.downloads)
                     {


### PR DESCRIPTION
**Changes**
- Add "status" to Mod object
- Check if mod wasn't declined before checking if any of it's file hashes match installed files.
- Clarify "Check Installed Mods" -> "Detect Installed Mods". (This was confusing since selected mods are shown a *check*mark.)

**Details**
When detecting installed mods, Mod Assistant checks all possible mod related files in the Beat Saber directory against all files returned by the Beat Mods API.
Occasionally mods get uploaded to Beat Mods containing extra files that aren't supposed to be there, and these mods get declined. However, the Beat Mods API returns every upload in the db. Even mods that were "declined" for having invalid folder structures. 

This could cause Mod Assistant to think that `Custom Notes` was installed if there was a declined version uploaded to Beat Mods containing `BS_Utils.dll` that matched the hash of the installed version of `BS_Utils.dll`

**Drawbacks**
I opted to only check for "declined" mods, which unfortunately means that "inactive" or "pending" mods can still cause this issue. Including either of these could cause the user to be unable to uninstall mods from the old game version or mods that have not yet been approved.
I also think it would be a bad solution to only check if "approved" mods are installed, because then the version detection would show an old version installed, but not show the button to uninstall it.

Closes #123 