### PR TITLE
Enable TLS 1.2 security protocol

### DIFF
--- a/ModAssistant/App.xaml.cs
+++ b/ModAssistant/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -25,6 +26,9 @@ namespace ModAssistant
 
         private async void Application_Startup(object sender, StartupEventArgs e)
         {
+            // Set SecurityProtocol to prevent crash with TLS
+            System.Net.ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             // Load localisation languages
             LoadLanguage(CultureInfo.CurrentCulture.Name);
 


### PR DESCRIPTION
This is a slight modification of the fix in #83 

I looked into it a bit and found this discussion <https://stackoverflow.com/questions/28286086/default-securityprotocol-in-net-4-5/36454717#36454717>

To my understanding, instead of setting a strict security protocol, this enables the TLS 1.2 protocol, while leaving the system default enabled as well.

Closes #67 