### PR TITLE
Handle invalid semver from beatmods

### DIFF
--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -540,13 +540,14 @@ namespace ModAssistant.Pages
             {
                 get
                 {
-                    return !IsInstalled ? "-" : _installedVersion.ToString();
+                    if (!IsInstalled || _installedVersion == null) return "-";
+                    return _installedVersion.ToString();
                 }
                 set
                 {
-                    if (value != null)
+                    if (SemVersion.TryParse(value, out SemVersion tempInstalledVersion))
                     {
-                        _installedVersion = SemVersion.Parse(value);
+                        _installedVersion = tempInstalledVersion;
                     } else
                     {
                         _installedVersion = null;


### PR DESCRIPTION
This should fix MA crashing when a mod has an semver value, like in the screenshot below.

Tested by simply changing the parsed "value" to invalid semver values.