### PR TITLE
Use CurrentUICulture to determine display language

### DIFF
--- a/ModAssistant/App.xaml.cs
+++ b/ModAssistant/App.xaml.cs
@@ -36,7 +36,7 @@ namespace ModAssistant
             System.Net.ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             // Load localisation languages
-            LoadLanguage(CultureInfo.CurrentCulture.Name);
+            LoadLanguage(CultureInfo.CurrentUICulture.Name);
 
             // Uncomment the next line to debug localisation
             // LoadLanguage("en-DEBUG");


### PR DESCRIPTION
Fixes cases like #167 where the language is wrong.

Uses the display language instead of the region format.