### PR TITLE
Language select

### DIFF
--- a/ModAssistant/App.config
+++ b/ModAssistant/App.config
@@ -53,6 +53,9 @@
             <setting name="CloseWindowOnFinish" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="LanguageCode" serializeAs="String">
+                <value />
+            </setting>
         </ModAssistant.Properties.Settings>
         <ModAssistant.Settings1>
             <setting name="InstallFolder" serializeAs="String">

--- a/ModAssistant/App.xaml.cs
+++ b/ModAssistant/App.xaml.cs
@@ -35,12 +35,6 @@ namespace ModAssistant
             // Set SecurityProtocol to prevent crash with TLS
             System.Net.ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
-            // Load localisation languages
-            Languages.LoadLanguage(CultureInfo.CurrentCulture.Name);
-
-            // Uncomment the next line to debug localisation
-            // LoadLanguage("en-DEBUG");
-
             if (ModAssistant.Properties.Settings.Default.UpgradeRequired)
             {
                 ModAssistant.Properties.Settings.Default.Upgrade();

--- a/ModAssistant/App.xaml.cs
+++ b/ModAssistant/App.xaml.cs
@@ -36,7 +36,7 @@ namespace ModAssistant
             System.Net.ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             // Load localisation languages
-            Utils.LoadLanguage(CultureInfo.CurrentCulture.Name);
+            Languages.LoadLanguage(CultureInfo.CurrentCulture.Name);
 
             // Uncomment the next line to debug localisation
             // LoadLanguage("en-DEBUG");
@@ -142,7 +142,7 @@ namespace ModAssistant
                         }
                         else
                         {
-                            Utils.LoadLanguage(args[1]);
+                            Languages.LoadLanguage(args[1]);
                         }
 
                         args = Shift(args, 2);

--- a/ModAssistant/App.xaml.cs
+++ b/ModAssistant/App.xaml.cs
@@ -36,7 +36,7 @@ namespace ModAssistant
             System.Net.ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             // Load localisation languages
-            LoadLanguage(CultureInfo.CurrentCulture.Name);
+            Utils.LoadLanguage(CultureInfo.CurrentCulture.Name);
 
             // Uncomment the next line to debug localisation
             // LoadLanguage("en-DEBUG");
@@ -142,7 +142,7 @@ namespace ModAssistant
                         }
                         else
                         {
-                            LoadLanguage(args[1]);
+                            Utils.LoadLanguage(args[1]);
                         }
 
                         args = Shift(args, 2);
@@ -212,30 +212,6 @@ namespace ModAssistant
 
             e.Handled = true;
             Application.Current.Shutdown();
-        }
-
-        private ResourceDictionary LanguagesDict
-        {
-            get
-            {
-                return Resources.MergedDictionaries[1];
-            }
-        }
-
-        private void LoadLanguage(string culture)
-        {
-            try
-            {
-                LanguagesDict.Source = new Uri($"Localisation/{culture}.xaml", UriKind.Relative);
-            }
-            catch (IOException)
-            {
-                if (culture.Contains("-"))
-                {
-                    LoadLanguage(culture.Split('-').First());
-                }
-                // Can't load language file
-            }
         }
     }
 }

--- a/ModAssistant/Classes/Languages.cs
+++ b/ModAssistant/Classes/Languages.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using ModAssistant.Pages;
+
+namespace ModAssistant
+{
+    class Languages
+    {
+        public static string LoadedLanguage { get; private set; }
+        public static List<CultureInfo> LoadedLanguages { get => availableCultures.ToList(); }
+
+        private static string[] availableLanguageCodes = { "de", "en", "fr", "it", "ko", "nl", "ru", "zh" };
+
+        private static IEnumerable<CultureInfo> availableCultures;
+        public static void LoadLanguages()
+        {
+            var allCultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+            // Get CultureInfo for any of the available translations
+            availableCultures = allCultures.Where(cultureInfo => availableLanguageCodes.Any(code => code.CompareTo(cultureInfo.Name) == 0));
+
+            if (Options.Instance != null && Options.Instance.LanguageSelectComboBox != null)
+            {
+                Options.Instance.LanguageSelectComboBox.ItemsSource = availableCultures.Select(cultureInfo => cultureInfo.EnglishName).ToList();
+            }
+        }
+
+        private static ResourceDictionary LanguagesDict
+        {
+            get
+            {
+                return Application.Current.Resources.MergedDictionaries[1];
+            }
+        }
+
+        public static void LoadLanguage(string culture)
+        {
+            try
+            {
+                LanguagesDict.Source = new Uri($"Localisation/{culture}.xaml", UriKind.Relative);
+            }
+            catch (IOException)
+            {
+                if (culture.Contains("-"))
+                {
+                    LoadLanguage(culture.Split('-').First());
+                }
+                // Can't load language file
+            }
+        }
+    }
+}

--- a/ModAssistant/Classes/Languages.cs
+++ b/ModAssistant/Classes/Languages.cs
@@ -27,7 +27,7 @@ namespace ModAssistant
 
             if (Options.Instance != null && Options.Instance.LanguageSelectComboBox != null)
             {
-                Options.Instance.LanguageSelectComboBox.ItemsSource = availableCultures.Select(cultureInfo => cultureInfo.EnglishName).ToList();
+                Options.Instance.LanguageSelectComboBox.ItemsSource = availableCultures.Select(cultureInfo => cultureInfo.NativeName).ToList();
             }
         }
 

--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -439,5 +439,29 @@ namespace ModAssistant
             ShowMessageBoxDelegate caller = new ShowMessageBoxDelegate(ShowMessageBox);
             caller.BeginInvoke(Message, null, null, null);
         }
+
+        private static ResourceDictionary LanguagesDict
+        {
+            get
+            {
+                return Application.Current.Resources.MergedDictionaries[1];
+            }
+        }
+
+        public static void LoadLanguage(string culture)
+        {
+            try
+            {
+                LanguagesDict.Source = new Uri($"Localisation/{culture}.xaml", UriKind.Relative);
+            }
+            catch (IOException)
+            {
+                if (culture.Contains("-"))
+                {
+                    LoadLanguage(culture.Split('-').First());
+                }
+                // Can't load language file
+            }
+        }
     }
 }

--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -439,29 +439,5 @@ namespace ModAssistant
             ShowMessageBoxDelegate caller = new ShowMessageBoxDelegate(ShowMessageBox);
             caller.BeginInvoke(Message, null, null, null);
         }
-
-        private static ResourceDictionary LanguagesDict
-        {
-            get
-            {
-                return Application.Current.Resources.MergedDictionaries[1];
-            }
-        }
-
-        public static void LoadLanguage(string culture)
-        {
-            try
-            {
-                LanguagesDict.Source = new Uri($"Localisation/{culture}.xaml", UriKind.Relative);
-            }
-            catch (IOException)
-            {
-                if (culture.Contains("-"))
-                {
-                    LoadLanguage(culture.Split('-').First());
-                }
-                // Can't load language file
-            }
-        }
     }
 }

--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -65,6 +65,9 @@ namespace ModAssistant
             Themes.LoadThemes();
             Themes.FirstLoad(Properties.Settings.Default.SelectedTheme);
 
+            // Load languages into combobox
+            Languages.LoadLanguages();
+
             Task.Run(() => LoadVersionsAsync());
 
             if (!Properties.Settings.Default.Agreed || string.IsNullOrEmpty(Properties.Settings.Default.LastTab))

--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -65,7 +65,6 @@ namespace ModAssistant
             Themes.LoadThemes();
             Themes.FirstLoad(Properties.Settings.Default.SelectedTheme);
 
-            // Load languages into combobox
             Languages.LoadLanguages();
 
             Task.Run(() => LoadVersionsAsync());

--- a/ModAssistant/ModAssistant.csproj
+++ b/ModAssistant/ModAssistant.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Classes\External Interfaces\Utils.cs" />
     <Compile Include="Classes\Http.cs" />
     <Compile Include="Classes\HyperlinkExtensions.cs" />
+    <Compile Include="Classes\Languages.cs" />
     <Compile Include="Classes\Promotions.cs" />
     <Compile Include="Classes\Diagnostics.cs" />
     <Compile Include="Classes\Themes.cs" />

--- a/ModAssistant/Pages/Options.xaml
+++ b/ModAssistant/Pages/Options.xaml
@@ -295,6 +295,14 @@
             Padding="5"
             Click="ApplicationThemeOpenThemesFolder_Click"
             Content="{DynamicResource Options:OpenFolderButton}" />
+        <ComboBox
+            Name="LanguageSelectComboBox"
+            Grid.Row="14"
+            Grid.Column="1"
+            Height="30"
+            HorizontalAlignment="Stretch"
+            VerticalContentAlignment="Center"
+            SelectionChanged="LanguageSelectComboBox_SelectionChanged" />
 
         <TextBlock
             Grid.Row="14"

--- a/ModAssistant/Pages/Options.xaml
+++ b/ModAssistant/Pages/Options.xaml
@@ -47,6 +47,14 @@
             FontSize="24"
             FontWeight="Bold"
             Text="{DynamicResource Options:PageTitle}" />
+        <ComboBox
+            Name="LanguageSelectComboBox"
+            Grid.Row="0"
+            Grid.Column="3"
+            Height="30"
+            HorizontalAlignment="Stretch"
+            VerticalContentAlignment="Center"
+            SelectionChanged="LanguageSelectComboBox_SelectionChanged" />
 
         <TextBlock
             Grid.Row="1"
@@ -295,14 +303,6 @@
             Padding="5"
             Click="ApplicationThemeOpenThemesFolder_Click"
             Content="{DynamicResource Options:OpenFolderButton}" />
-        <ComboBox
-            Name="LanguageSelectComboBox"
-            Grid.Row="14"
-            Grid.Column="1"
-            Height="30"
-            HorizontalAlignment="Stretch"
-            VerticalContentAlignment="Center"
-            SelectionChanged="LanguageSelectComboBox_SelectionChanged" />
 
         <TextBlock
             Grid.Row="14"

--- a/ModAssistant/Pages/Options.xaml
+++ b/ModAssistant/Pages/Options.xaml
@@ -47,6 +47,15 @@
             FontSize="24"
             FontWeight="Bold"
             Text="{DynamicResource Options:PageTitle}" />
+
+        <TextBlock
+            Grid.Row="0"
+            Grid.Column="2"
+            Margin="5"
+            HorizontalAlignment="Right"
+            FontSize="22"
+            FontWeight="Bold"
+            Text="A 文" />
         <ComboBox
             Name="LanguageSelectComboBox"
             Grid.Row="0"

--- a/ModAssistant/Pages/Options.xaml.cs
+++ b/ModAssistant/Pages/Options.xaml.cs
@@ -331,6 +331,21 @@ namespace ModAssistant.Pages
             }
         }
 
+        public void LanguageSelectComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if ((sender as ComboBox).SelectedItem == null)
+            {
+                // Apply default language
+                Console.WriteLine("Applying default language");
+            }
+            else
+            {
+                // Set new language
+                Console.WriteLine("Setting language to:" + (sender as ComboBox).SelectedItem.ToString());
+                //LoadLanguage((sender as ComboBox).SelectedItem.ToString())
+            }
+        }
+
         private void ApplicationThemeExportTemplate_Click(object sender, RoutedEventArgs e)
         {
             Themes.WriteThemeToDisk("Ugly Kulu-Ya-Ku");

--- a/ModAssistant/Pages/Options.xaml.cs
+++ b/ModAssistant/Pages/Options.xaml.cs
@@ -337,12 +337,14 @@ namespace ModAssistant.Pages
             {
                 // Apply default language
                 Console.WriteLine("Applying default language");
+                Languages.LoadLanguage("en");
             }
             else
             {
-                // Set new language
-                Console.WriteLine("Setting language to:" + (sender as ComboBox).SelectedItem.ToString());
-                //LoadLanguage((sender as ComboBox).SelectedItem.ToString())
+                // Get the matching language from the LoadedLanguages array, then try and use it
+                var languageName = (sender as ComboBox).SelectedItem.ToString();
+                var selectedLanguage = Languages.LoadedLanguages.Find(language => language.EnglishName.CompareTo(languageName) == 0);
+                Languages.LoadLanguage(selectedLanguage.Name);
             }
         }
 

--- a/ModAssistant/Pages/Options.xaml.cs
+++ b/ModAssistant/Pages/Options.xaml.cs
@@ -343,7 +343,7 @@ namespace ModAssistant.Pages
             {
                 // Get the matching language from the LoadedLanguages array, then try and use it
                 var languageName = (sender as ComboBox).SelectedItem.ToString();
-                var selectedLanguage = Languages.LoadedLanguages.Find(language => language.EnglishName.CompareTo(languageName) == 0);
+                var selectedLanguage = Languages.LoadedLanguages.Find(language => language.NativeName.CompareTo(languageName) == 0);
                 Languages.LoadLanguage(selectedLanguage.Name);
             }
         }

--- a/ModAssistant/Properties/Settings.Designer.cs
+++ b/ModAssistant/Properties/Settings.Designer.cs
@@ -190,5 +190,17 @@ namespace ModAssistant.Properties {
                 this["CloseWindowOnFinish"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LanguageCode {
+            get {
+                return ((string)(this["LanguageCode"]));
+            }
+            set {
+                this["LanguageCode"] = value;
+            }
+        }
     }
 }

--- a/ModAssistant/Properties/Settings.settings
+++ b/ModAssistant/Properties/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="CloseWindowOnFinish" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LanguageCode" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
New features
- Language select box in the Options menu that lets you set the UI language.
- New "Languages" class based off of the "Themes" class for handling language loading.
- Selected language is saved and loaded on startup. If no saved language is detected, it loads the system language. If the system language isn't supported, it loads English instead.

Thankfully the UI seems to completely refresh when the language is changed, so this PR mostly has to do with selecting the language.

TODO:
- Figure out where to put the dropdown box in the UI. It's getting pretty cramped.
- Get list of language files in the `Localizations` folder instead of using a hardcoded array. I spent about an hour trying to figure this out, but since the language files are stored inside the executable and accessed with a URI, the common solutions to getting a list of files in a directory didn't seem to work. For example, `Directory.GetFiles`

![image](https://user-images.githubusercontent.com/27714637/83318981-e6853780-a1ee-11ea-965d-d8639892a442.png)

Closes #174
Closes #167  