### PR TITLE
Force shutdown app when main window closed

### DIFF
--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -95,6 +95,21 @@ namespace ModAssistant
             }
         }
 
+        /* Force the app to shutdown when The main window is closed.
+         *
+         * Explaination:
+         * OneClickStatus is initialized as a static object,
+         * so the window will exist, even if it is unused.
+         * This would cause Mod Assistant to not shutdown,
+         * because technically a window was still open.
+         */
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            Application.Current.Shutdown();
+        }
+
         private async void LoadVersionsAsync()
         {
             try


### PR DESCRIPTION
This should fix Mod Assistant not closing when the main window is closed.
I imagine most people didn't even notice this because MA has such a small footprint.