### PR TITLE
Fix text not fitting inside buttons

### DIFF
--- a/ModAssistant/MainWindow.xaml
+++ b/ModAssistant/MainWindow.xaml
@@ -166,8 +166,8 @@
             <Grid Grid.Row="1" Grid.Column="1">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="115" />
-                    <ColumnDefinition Width="115" />
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="auto" />
                 </Grid.ColumnDefinitions>
 
                 <Border
@@ -184,9 +184,10 @@
                 <Button
                     Name="InfoButton"
                     Grid.Column="1"
-                    Width="100"
                     Height="40"
-                    Margin="0,10,0,0"
+                    MinWidth="115"
+                    Margin="10,10,0,0"
+                    Padding="20,0,20,0"
                     HorizontalAlignment="Right"
                     Click="InfoButton_Click"
                     IsEnabled="False">
@@ -197,32 +198,27 @@
                             Text="{DynamicResource MainWindow:ModInfoButton}" />
                     </StackPanel>
                 </Button>
-
-                <StackPanel 
-                    Grid.Column="2" Orientation="Horizontal"
+                <Button
+                    Name="InstallButton"
+                    Grid.Column="2" 
                     Height="40"
-                    Width="100"
-                    Margin="0,10,0,0"
-                    HorizontalAlignment="Right">
-                    <Button
-                        Name="InstallButton"
-                        Width="100"
-                        Height="40"
-                        HorizontalAlignment="Right"
-                        Click="InstallButton_Click"
-                        IsEnabled="False">
-                        <StackPanel>
-                            <TextBlock
+                    MinWidth="115"
+                    Margin="10,10,0,0"
+                    Padding="20,0,20,0"
+                    HorizontalAlignment="Right"
+                    Click="InstallButton_Click"
+                    IsEnabled="False">
+                    <StackPanel>
+                        <TextBlock
                             HorizontalAlignment="Center"
                             VerticalAlignment="Bottom"
                             Text="{DynamicResource MainWindow:InstallButtonTop}" />
-                            <TextBlock
+                        <TextBlock
                             HorizontalAlignment="Center"
                             VerticalAlignment="Bottom"
                             Text="{DynamicResource MainWindow:InstallButtonBottom}" />
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
+                    </StackPanel>
+                </Button>
             </Grid>
         </Grid>
     </Grid>

--- a/ModAssistant/MainWindow.xaml
+++ b/ModAssistant/MainWindow.xaml
@@ -58,16 +58,17 @@
                     Margin="0,0,10,5"
                     Click="IntroButton_Click"
                     Style="{DynamicResource MainPageButton}">
-                    <StackPanel Margin="0,8,0,0">
+                    <StackPanel Margin="0,6,0,0">
                         <Image
                             Height="30"
                             VerticalAlignment="Bottom"
                             Source="{StaticResource info_circleDrawingImage}" />
-                        <TextBlock
-                            Margin="0,0,0,5"
+                        <Viewbox Stretch="Uniform" Height="16">
+                            <TextBlock
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Bottom"
+                            Padding="2,0,2,0"
                             Text="{DynamicResource MainWindow:IntroButton}" />
+                        </Viewbox>
                     </StackPanel>
                 </Button>
 
@@ -84,11 +85,12 @@
                             Height="30"
                             VerticalAlignment="Bottom"
                             Source="{StaticResource microchipDrawingImage}" />
-                        <TextBlock
-                            Margin="0,0,0,5"
+                        <Viewbox Stretch="Uniform" Height="16">
+                            <TextBlock
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Bottom"
+                            Padding="2,0,2,0"
                             Text="{DynamicResource MainWindow:ModsButton}" />
+                        </Viewbox>
                     </StackPanel>
                 </Button>
 
@@ -104,11 +106,12 @@
                             Height="30"
                             VerticalAlignment="Bottom"
                             Source="{StaticResource heartDrawingImage}" />
-                        <TextBlock
-                            Margin="0,0,0,5"
+                        <Viewbox Stretch="Uniform" Height="16">
+                            <TextBlock
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Bottom"
+                            Padding="2,0,2,0"
                             Text="{DynamicResource MainWindow:AboutButton}" />
+                        </Viewbox>
                     </StackPanel>
                 </Button>
 
@@ -124,11 +127,12 @@
                             Height="30"
                             VerticalAlignment="Bottom"
                             Source="{StaticResource cogDrawingImage}" />
-                        <TextBlock
-                            Margin="0,0,0,5"
+                        <Viewbox Stretch="Uniform" Height="16">
+                            <TextBlock
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Bottom"
+                            Padding="2,0,2,0"
                             Text="{DynamicResource MainWindow:OptionsButton}" />
+                        </Viewbox>
                     </StackPanel>
                 </Button>
 

--- a/ModAssistant/Pages/About.xaml
+++ b/ModAssistant/Pages/About.xaml
@@ -251,17 +251,19 @@
             Orientation="Horizontal">
             <Button
                 x:Name="PatButton"
-                Width="80"
                 Height="30"
+                MinWidth="80"
                 Margin="0,0,5,0"
+                Padding="20,0,20,0"
                 x:FieldModifier="public"
                 Click="HeadpatsButton_Click"
                 Content="{DynamicResource About:HeadpatsButton}" />
             <Button
                 x:Name="HugButton"
-                Width="80"
                 Height="30"
+                MinWidth="80"
                 Margin="5,0,0,0"
+                Padding="20,0,20,0"
                 x:FieldModifier="public"
                 Click="HugsButton_Click"
                 Content="{DynamicResource About:HugsButton}" />

--- a/ModAssistant/Pages/Intro.xaml
+++ b/ModAssistant/Pages/Intro.xaml
@@ -110,9 +110,9 @@
             Orientation="Horizontal">
             <Button
                 Name="Agree"
-                Width="100"
                 Height="35"
                 Margin="0,0,10,0"
+                Padding="20,0,20,0"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Click="Agree_Click">
@@ -124,9 +124,9 @@
             </Button>
             <Button
                 Name="Disagree"
-                Width="100"
                 Height="35"
                 Margin="10,0,0,0"
+                Padding="20,0,20,0"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Click="Disagree_Click">


### PR DESCRIPTION
This should fix button text not fitting inside of buttons for certain languages.

I did this by making the button and column widths adjust automatically while observing a minimum width. Unfortunately for the sidebar buttons, I had to scale the text if it was too wide, which makes it a bit difficult to read.

Fixed:
- Sidebar buttons
- Intro accept / decline buttons
- Install / Mod Info buttons
- Headpats / Hugs buttons

![image](https://user-images.githubusercontent.com/27714637/83580172-2cdcde00-a4f0-11ea-8205-682432386c11.png)

![image](https://user-images.githubusercontent.com/27714637/83580185-3a926380-a4f0-11ea-8ab4-ada9ece82688.png)

![image](https://user-images.githubusercontent.com/27714637/83580262-6a416b80-a4f0-11ea-918d-5cecdcdf5a1f.png)
