### PR TITLE
Don't attempt to access non-existent manifest resources

### DIFF
--- a/ModAssistant/Classes/Themes.cs
+++ b/ModAssistant/Classes/Themes.cs
@@ -433,9 +433,19 @@ namespace ModAssistant
 
         private static BitmapImage GetImageFromEmbeddedResources(string themeName, string imageName)
         {
+            var assembly = Assembly.GetExecutingAssembly();
+            var resourceNames = assembly.GetManifestResourceNames();
+            var desiredResourceName = $"ModAssistant.Themes.{themeName}.{imageName}.png";
+
+            // Don't attempt to access non-existent manifest resources
+            if (!resourceNames.Contains(desiredResourceName))
+            {
+                return null;
+            }
+
             try
             {
-                using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"ModAssistant.Themes.{themeName}.{imageName}.png"))
+                using (Stream stream = assembly.GetManifestResourceStream(desiredResourceName))
                 {
                     byte[] imageBytes = new byte[stream.Length];
                     stream.Read(imageBytes, 0, (int)stream.Length);


### PR DESCRIPTION
When launching the application from Visual Studio (in the `Debug` configuration), multiple `NullReferenceException`s are thrown as a result of an attempt to access manifest resource streams that do not exist (twice for each of the built-in themes, it would seem).

These exceptions are thrown inside of a `try`/`catch` block, so they do not pose issues to end-users.

However, in the default configuration of Visual Studio 2019 the debugger will break on many types of exceptions, regardless of whether they have been handled or not.  While this behavior can be disabled (<kbd>Debug</kbd> &raquo; <kbd>Windows</kbd> &raquo; <kbd>Exception Settings</kbd> &raquo; Uncheck "Common Language Runtime Exceptions"), a novice may not understand how to do this, and also may not realize that they can simply continue execution.

Regardless of the above, it is generally regarded as a good thing to refrain from throwing exceptions whenever possible, and these exceptions can be prevented entirely by merely checking for the existence of a given resource by name prior to accessing it.