### PR TITLE
Suppress exceptions when setting clipboard data

### DIFF
--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -439,5 +439,30 @@ namespace ModAssistant
             ShowMessageBoxDelegate caller = new ShowMessageBoxDelegate(ShowMessageBox);
             caller.BeginInvoke(Message, null, null, null);
         }
+
+        /// <summary>
+        /// Attempts to write the specified string to the <see cref="System.Windows.Clipboard"/>.
+        /// </summary>
+        /// <param name="text">The string to be written</param>
+        public static void SetClipboard(string text)
+        {
+            bool success = false;
+            try
+            {
+                Clipboard.SetText(text);
+                success = true;
+            }
+            catch (Exception)
+            {
+                // Swallow exceptions relating to writing data to clipboard.
+            }
+
+            // This could be placed in the try/catch block but we don't
+            // want to suppress exceptions for non-clipboard operations
+            if (success)
+            {
+                Utils.SendNotify($"Copied text to clipboard");
+            }
+        }
     }
 }

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -716,8 +716,14 @@ namespace ModAssistant.Pages
 
         private void CopyText(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            System.Windows.Clipboard.SetText(((TextBlock)sender).Text);
-            Utils.SendNotify("Copied text to clipboard");
+            var textBlock = sender as TextBlock;
+            if (textBlock == null) { return; }
+            var text = textBlock.Text;
+
+            // Ensure there's text to be copied
+            if (string.IsNullOrWhiteSpace(text)) { return; }
+
+            Utils.SetClipboard(text);
         }
 
         private void SearchButton_Click(object sender, RoutedEventArgs e)

--- a/ModAssistant/Pages/Options.xaml.cs
+++ b/ModAssistant/Pages/Options.xaml.cs
@@ -206,7 +206,7 @@ namespace ModAssistant.Pages
                 await Task.Run(async () => await UploadLog());
 
                 System.Diagnostics.Process.Start(LogURL);
-                Clipboard.SetText(LogURL);
+                Utils.SetClipboard(LogURL);
                 MainWindow.Instance.MainText = (string)Application.Current.FindResource("Options:LogUrlCopied");
             }
             catch (Exception exception)


### PR DESCRIPTION
The Clipboard is a shared system resource and thus can only be accessed by a single application at any given moment.  While an application is accessing the clipboard, any attempts made by another application will fail.

Since most operations involving the clipboard are initiated by the user (e.g. copy/paste), and because the user can only have a single window active at any given time, it is unlikely for multiple applications to access the clipboard concurrently.

One such scenario may occur when using Remote Desktop to connect to a remote machine while sharing your clipboard.  This causes the clipboard contents to be synchronized between the local and remote machines, and this has the occasional side-effect of locking the clipboard for extended periods of time.

In fact, the reference source for the `System.Windows.Clipboard` class specifically mentions this scenario and implements a workaround by retrying operations after a small delay.  ([10 attempts](https://referencesource.microsoft.com/#PresentationCore/Core/CSharp/System/Windows/Clipboard.cs,944) with [100ms delay](https://referencesource.microsoft.com/#PresentationCore/Core/CSharp/System/Windows/Clipboard.cs,952) between attempts)

This pull request consolidates the two usages of `Clipboard.SetText(string)` into a new static method defined in the `Utils` class.  This method (`Utils.SetClipboard(string)`) does nothing more than wrap the method call in a `try`/`catch` block so that these exceptions do not cause the application to crash.  The notification balloon is only shown when the operation was successful, but no indication is made to the user if the operation failed.

Resolves #188 