### PR TITLE
Add "2 Click Install" feature

### DIFF
--- a/ModAssistant/App.config
+++ b/ModAssistant/App.config
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="ModAssistant.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
             <section name="ModAssistant.Settings1" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
+        <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
     </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
@@ -69,4 +70,30 @@
             </setting>
         </ModAssistant.Settings1>
     </userSettings>
+    <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <targets>
+            <target name="callmethod" xsi:type="MethodCall" className="ModAssistant.Utils, ModAssistant" methodName="Log">
+                <parameter layout="${message}" />
+                <parameter layout="${level}" />
+            </target>
+        </targets>
+        <rules>
+            <logger name="*" minlevel="Debug" writeTo="callmethod">
+                <when condition="equals('${logger}','SoundFingerprinting.Emy.FFmpeg.Loader.WindowsLoader')" action="Ignore" />
+                <when condition="equals('${logger}','FFmpeg')" action="Ignore" />
+            </logger>
+        </rules>
+    </nlog>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/ModAssistant/Classes/External Interfaces/BeatSaver.cs
+++ b/ModAssistant/Classes/External Interfaces/BeatSaver.cs
@@ -199,7 +199,7 @@ namespace ModAssistant.API
                     {
                         if (showNotification)
                         {
-                            MessageBox.Show($"{Application.Current.FindResource("OneClick:PatchingFailed")}");
+                            MessageBox.Show($"{Application.Current.FindResource("OneClick:PatchSong:Failed")}");
                         }
                         throw new Exception("Verification and patching failed.");
                     }

--- a/ModAssistant/Classes/External Interfaces/SongPatcher.cs
+++ b/ModAssistant/Classes/External Interfaces/SongPatcher.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using SaberSongPatcher;
+
+namespace ModAssistant.API
+{
+    public class SongPatcher
+    {
+        public static async Task<bool> PromptAndPatchSongFromDisk(string directory)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            var supportedExtensions = new[]
+            {
+                "mp3",
+                "m4a",
+                "ogg",
+                "wav",
+                "flac",
+                "aiff",
+                "wma",
+            };
+            var audioExtensions = string.Join(";", supportedExtensions.Select(ext => $"*.{ext}"));
+            openFileDialog.Title = "Select master song audio file";
+            openFileDialog.Filter = $"Audio files ({audioExtensions})|{audioExtensions}|All files (*.*)|*.*";
+            openFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+
+            var success = false;
+            if (openFileDialog.ShowDialog() == DialogResult.OK)
+            {
+                success = await PerformPatch(openFileDialog.FileName, directory);
+            }
+            return success;
+        }
+
+        private static async Task<bool> PerformPatch(string inputFile, string mapDirectory)
+        {
+            var config = ConfigParser.ParseConfig(true, mapDirectory);
+            var context = new Context(config);
+            var inputValidator = new InputValidator(context);
+            var inputTransformer = new InputTransformer(context);
+
+            var seemsCorrect = await inputValidator.ValidateInput(inputFile, mapDirectory);
+            if (!seemsCorrect)
+            {
+                return false;
+            }
+
+            var outputFile = Path.Combine(mapDirectory, "song.egg");
+            var success = await inputTransformer.TransformInput(inputFile, outputFile);
+            if (!success)
+            {
+                throw new Exception("Failed to transform audio.");
+            }
+
+            return true;
+        }
+    }
+}

--- a/ModAssistant/Localisation/de.xaml
+++ b/ModAssistant/Localisation/de.xaml
@@ -216,6 +216,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Beat Saber Installationspfad nicht gefunden.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installiert: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Installation fehlgeschlagen.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ Installation Handler registriert!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ Installation Handler entfernt!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String> <!-- NEEDS TRANSLATING -->

--- a/ModAssistant/Localisation/de.xaml
+++ b/ModAssistant/Localisation/de.xaml
@@ -216,7 +216,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Beat Saber Installationspfad nicht gefunden.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installiert: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Installation fehlgeschlagen.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ Installation Handler registriert!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ Installation Handler entfernt!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String> <!-- NEEDS TRANSLATING -->

--- a/ModAssistant/Localisation/en-DEBUG.xaml
+++ b/ModAssistant/Localisation/en-DEBUG.xaml
@@ -157,7 +157,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">OneClick:InstallDirNotFound</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">{0} OneClick:InstalledAsset</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">OneClick:AssetInstallFailed</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">OneClick:PatchingFailed</sys:String>
+    <sys:String x:Key="OneClick:PatchSong:Failed">OneClick:PatchSong:Failed</sys:String>
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">OneClick:PatchSong:SelectFile</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick:ProtocolHandler:Registered</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick:ProtocolHandler:Unregistered</sys:String>
     <sys:String x:Key="OneClick:Installing">{0} OneClick:Installing</sys:String>

--- a/ModAssistant/Localisation/en-DEBUG.xaml
+++ b/ModAssistant/Localisation/en-DEBUG.xaml
@@ -157,6 +157,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">OneClick:InstallDirNotFound</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">{0} OneClick:InstalledAsset</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">OneClick:AssetInstallFailed</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">OneClick:PatchingFailed</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick:ProtocolHandler:Registered</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick:ProtocolHandler:Unregistered</sys:String>
     <sys:String x:Key="OneClick:Installing">{0} OneClick:Installing</sys:String>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -220,6 +220,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Beat Saber installation path not found.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installed: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Failed to install.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ Install handlers registered!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ Install handlers unregistered!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -220,7 +220,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Beat Saber installation path not found.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installed: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Failed to install.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String>
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String>
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ Install handlers registered!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ Install handlers unregistered!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String>

--- a/ModAssistant/Localisation/fr.xaml
+++ b/ModAssistant/Localisation/fr.xaml
@@ -223,6 +223,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Chemin de l'installation de Beat Saber non trouvé.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installé : {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Échec de l'installation.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} : gestionnaires d'installation OneClick™ inscrits !</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} : gestionnaires d'installation OneClick™ désinscrits !</sys:String>
     <sys:String x:Key="OneClick:Installing">Installation de : {0}</sys:String>

--- a/ModAssistant/Localisation/fr.xaml
+++ b/ModAssistant/Localisation/fr.xaml
@@ -223,7 +223,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Chemin de l'installation de Beat Saber non trouvé.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installé : {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Échec de l'installation.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} : gestionnaires d'installation OneClick™ inscrits !</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} : gestionnaires d'installation OneClick™ désinscrits !</sys:String>
     <sys:String x:Key="OneClick:Installing">Installation de : {0}</sys:String>

--- a/ModAssistant/Localisation/it.xaml
+++ b/ModAssistant/Localisation/it.xaml
@@ -216,6 +216,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Directory d'installazione di Beat Saber non trovata.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installato: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Non sono riuscito ad installare la mappa.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String>  <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} Registrazione dei gestori OneClick™ riuscita!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} De-Regitrazione dei gestori OneClick™ riuscita!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String> <!-- NEEDS TRANSLATING -->

--- a/ModAssistant/Localisation/it.xaml
+++ b/ModAssistant/Localisation/it.xaml
@@ -216,7 +216,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Directory d'installazione di Beat Saber non trovata.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installato: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Non sono riuscito ad installare la mappa.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String>  <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String>  <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} Registrazione dei gestori OneClick™ riuscita!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} De-Regitrazione dei gestori OneClick™ riuscita!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String> <!-- NEEDS TRANSLATING -->

--- a/ModAssistant/Localisation/ko.xaml
+++ b/ModAssistant/Localisation/ko.xaml
@@ -215,7 +215,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">비트세이버 설치 폴더를 찾을 수 없었습니다.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">설치됨: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">설치에 실패하였습니다.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ 설치 관리자가 등록되었습니다!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ 설치 관리자가 등록 취소되었습니다!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String> <!-- NEEDS TRANSLATING -->

--- a/ModAssistant/Localisation/ko.xaml
+++ b/ModAssistant/Localisation/ko.xaml
@@ -215,6 +215,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">비트세이버 설치 폴더를 찾을 수 없었습니다.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">설치됨: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">설치에 실패하였습니다.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ 설치 관리자가 등록되었습니다!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ 설치 관리자가 등록 취소되었습니다!</sys:String>
     <sys:String x:Key="OneClick:Installing">Installing: {0}</sys:String> <!-- NEEDS TRANSLATING -->

--- a/ModAssistant/Localisation/nl.xaml
+++ b/ModAssistant/Localisation/nl.xaml
@@ -214,6 +214,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Kon het Beat Saber installatie pad niet vinden</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">{0} Geïnstalleerd</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Installatie mislukt</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ Installeer afhandelingen geregistreerd!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ Install afhandelingen uitgeregistreerd!</sys:String>
     <sys:String x:Key="OneClick:Installing">{0} word geïnstalleerd</sys:String>

--- a/ModAssistant/Localisation/nl.xaml
+++ b/ModAssistant/Localisation/nl.xaml
@@ -214,7 +214,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Kon het Beat Saber installatie pad niet vinden</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">{0} Geïnstalleerd</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Installatie mislukt</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ Installeer afhandelingen geregistreerd!</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ Install afhandelingen uitgeregistreerd!</sys:String>
     <sys:String x:Key="OneClick:Installing">{0} word geïnstalleerd</sys:String>

--- a/ModAssistant/Localisation/ru.xaml
+++ b/ModAssistant/Localisation/ru.xaml
@@ -216,6 +216,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Установочный путь к Beat Saber не найден.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Установлено: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Ошибка установки.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ установки зарегистрированы</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ установки не зарегистрированы!</sys:String>
     <sys:String x:Key="OneClick:Installing">Установка: {0}</sys:String> 

--- a/ModAssistant/Localisation/ru.xaml
+++ b/ModAssistant/Localisation/ru.xaml
@@ -216,7 +216,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">Установочный путь к Beat Saber не найден.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Установлено: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Ошибка установки.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ установки зарегистрированы</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ установки не зарегистрированы!</sys:String>
     <sys:String x:Key="OneClick:Installing">Установка: {0}</sys:String> 

--- a/ModAssistant/Localisation/sv.xaml
+++ b/ModAssistant/Localisation/sv.xaml
@@ -205,6 +205,7 @@
     <sys:String x:Key="OneClick:SongDownload:Failed">Det gick inte att ladda ned låten.</sys:String>
     <sys:String x:Key="OneClick:SongDownload:NetworkIssues">Det kan vara strul med BeatSaver eller din internetuppkoppling.</sys:String>
     <sys:String x:Key="OneClick:SongDownload:FailedTitle">Misslyckades med att ladda ned låtens ZIP-fil.</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:InstallDirNotFound">Det gick inte att hitta installationsvägen för Beat Saber.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installerade: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Misslyckades med att installera.</sys:String>

--- a/ModAssistant/Localisation/sv.xaml
+++ b/ModAssistant/Localisation/sv.xaml
@@ -205,7 +205,8 @@
     <sys:String x:Key="OneClick:SongDownload:Failed">Det gick inte att ladda ned låten.</sys:String>
     <sys:String x:Key="OneClick:SongDownload:NetworkIssues">Det kan vara strul med BeatSaver eller din internetuppkoppling.</sys:String>
     <sys:String x:Key="OneClick:SongDownload:FailedTitle">Misslyckades med att ladda ned låtens ZIP-fil.</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:InstallDirNotFound">Det gick inte att hitta installationsvägen för Beat Saber.</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">Installerade: {0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">Misslyckades med att installera.</sys:String>

--- a/ModAssistant/Localisation/zh.xaml
+++ b/ModAssistant/Localisation/zh.xaml
@@ -215,7 +215,8 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">找不到Beat Saber安装路径。</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">已添加：{0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">添加失败。</sys:String>
-    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:Failed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="OneClick:PatchSong:SelectFile">Select master song audio file</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ 一键添加处理程序已注册！</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ 一键添加处理程序已移除！</sys:String>
     <sys:String x:Key="OneClick:Installing">正在下载：{0}</sys:String>

--- a/ModAssistant/Localisation/zh.xaml
+++ b/ModAssistant/Localisation/zh.xaml
@@ -215,6 +215,7 @@
     <sys:String x:Key="OneClick:InstallDirNotFound">找不到Beat Saber安装路径。</sys:String>
     <sys:String x:Key="OneClick:InstalledAsset">已添加：{0}</sys:String>
     <sys:String x:Key="OneClick:AssetInstallFailed">添加失败。</sys:String>
+    <sys:String x:Key="OneClick:PatchingFailed">Input audio file does not match master audio file for this map.</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="OneClick:ProtocolHandler:Registered">{0} OneClick™ 一键添加处理程序已注册！</sys:String>
     <sys:String x:Key="OneClick:ProtocolHandler:Unregistered">{0} OneClick™ 一键添加处理程序已移除！</sys:String>
     <sys:String x:Key="OneClick:Installing">正在下载：{0}</sys:String>

--- a/ModAssistant/ModAssistant.csproj
+++ b/ModAssistant/ModAssistant.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -15,22 +15,6 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>1</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <PublishWizardCompleted>true</PublishWizardCompleted>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -53,18 +37,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestCertificateThumbprint>D52D100DAF433D9AB2FC684A9CDC145C85D477A0</ManifestCertificateThumbprint>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestKeyFile>ModAssistant_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <GenerateManifests>true</GenerateManifests>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignManifests>true</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FFmpeg.AutoGen, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9b7632533a381715, processorArchitecture=MSIL">
@@ -374,7 +346,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="ModAssistant_TemporaryKey.pfx" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>PublicSettingsSingleFileGenerator</Generator>
@@ -389,18 +360,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Themes\BSMG\Sidebar.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets" Condition="Exists('..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets')" />

--- a/ModAssistant/ModAssistant.csproj
+++ b/ModAssistant/ModAssistant.csproj
@@ -15,6 +15,22 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,6 +53,18 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestCertificateThumbprint>D52D100DAF433D9AB2FC684A9CDC145C85D477A0</ManifestCertificateThumbprint>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestKeyFile>ModAssistant_TemporaryKey.pfx</ManifestKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateManifests>true</GenerateManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignManifests>true</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FFmpeg.AutoGen, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9b7632533a381715, processorArchitecture=MSIL">
@@ -346,6 +374,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="ModAssistant_TemporaryKey.pfx" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>PublicSettingsSingleFileGenerator</Generator>
@@ -360,6 +389,18 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Themes\BSMG\Sidebar.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets" Condition="Exists('..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets')" />

--- a/ModAssistant/ModAssistant.csproj
+++ b/ModAssistant/ModAssistant.csproj
@@ -13,6 +13,8 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,13 +39,63 @@
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FFmpeg.AutoGen, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9b7632533a381715, processorArchitecture=MSIL">
+      <HintPath>..\packages\FFmpeg.AutoGen.4.2.0\lib\net45\FFmpeg.AutoGen.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json.Schema, Version=3.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.Schema.3.0.13\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.7.3\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.3.0.29\lib\net461\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.Core.3.0.29\lib\net461\protobuf-net.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="SaberSongPatcherCommon, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SaberSongPatcher.1.0.2\lib\netstandard2.0\SaberSongPatcherCommon.dll</HintPath>
+    </Reference>
+    <Reference Include="SoundFingerprinting, Version=7.4.12.100, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SoundFingerprinting.7.4.12\lib\netstandard2.0\SoundFingerprinting.dll</HintPath>
+    </Reference>
+    <Reference Include="SoundFingerprinting.Emy, Version=7.4.12.100, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SoundFingerprinting.Emy.7.4.12\lib\netstandard2.0\SoundFingerprinting.Emy.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Primitives, Version=4.7.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ServiceModel.Primitives.4.7.0\lib\net461\System.ServiceModel.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
@@ -60,6 +112,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsFormsIntegration" />
+    <Reference Include="Xabe.FFmpeg, Version=4.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xabe.FFmpeg.4.1.1\lib\netstandard2.0\Xabe.FFmpeg.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -69,6 +124,7 @@
     <Compile Include="Classes\External Interfaces\BeatSaver.cs" />
     <Compile Include="Classes\External Interfaces\ModelSaber.cs" />
     <Compile Include="Classes\External Interfaces\Playlists.cs" />
+    <Compile Include="Classes\External Interfaces\SongPatcher.cs" />
     <Compile Include="Classes\External Interfaces\Utils.cs" />
     <Compile Include="Classes\Http.cs" />
     <Compile Include="Classes\HyperlinkExtensions.cs" />
@@ -290,6 +346,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>PublicSettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -305,4 +362,11 @@
     <EmbeddedResource Include="Themes\BSMG\Sidebar.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets" Condition="Exists('..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SaberSongPatcher.1.0.2\build\SaberSongPatcher.targets'))" />
+  </Target>
 </Project>

--- a/ModAssistant/packages.config
+++ b/ModAssistant/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FFmpeg.AutoGen" version="4.2.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json.Schema" version="3.0.13" targetFramework="net461" />
+  <package id="NLog" version="4.7.3" targetFramework="net461" />
+  <package id="protobuf-net" version="3.0.29" targetFramework="net461" />
+  <package id="protobuf-net.Core" version="3.0.29" targetFramework="net461" />
+  <package id="SaberSongPatcher" version="1.0.2" targetFramework="net461" />
+  <package id="SoundFingerprinting" version="7.4.12" targetFramework="net461" />
+  <package id="SoundFingerprinting.Emy" version="7.4.12" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.ServiceModel.Primitives" version="4.7.0" targetFramework="net461" />
+  <package id="Xabe.FFmpeg" version="4.1.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
**Background**

Optional feature support for installing custom maps that do not contain any audio file.

This is part of a series of changes aimed at allowing custom maps to be created, uploaded, and used all without distributing any song file directly (instead the user must supply their own song). 

See this post for more background: https://medium.com/@idolize/beat-saber-the-future-of-custom-songs-d64756818be7

**Change**

Upon detecting there is no included audio in the download (but there is audio.json and fingerprint.bin):

1. Prompts user to select a master audio file to use with the map
1. Utilizes [SaberSongPatcher](https://www.nuget.org/packages/SaberSongPatcher/) NuGet package published from https://github.com/idolize/saber-song-patcher to verify the song works with the map
1. Patches the song with any tweaks
1. Renames and re-encodes the song to whatever file name is listed in `Info.dat`

Tested locally using custom BeatSaver instance.

** Related**

https://github.com/lolPants/beatsaver-reloaded/pull/85
https://github.com/lolPants/beatmap-schemas/pull/10