### PR TITLE
Issue #239: Quick hotfix for error that comes if not up-to-date

### DIFF
--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -120,11 +120,11 @@ namespace ModAssistant
 
                 resp = await HttpClient.GetAsync(Utils.Constants.BeatModsAlias);
                 body = await resp.Content.ReadAsStringAsync();
-                object jsonObject = JsonSerializer.DeserializeObject(body);
+                Dictionary<string, string[]> aliases = JsonSerializer.Deserialize<Dictionary<string, string[]>>(body);
 
                 Dispatcher.Invoke(() =>
                 {
-                    GameVersion = GetGameVersion(versions, jsonObject);
+                    GameVersion = GetGameVersion(versions, aliases);
 
                     GameVersionsBox.ItemsSource = versions;
                     GameVersionsBox.SelectedValue = GameVersion;
@@ -157,7 +157,7 @@ namespace ModAssistant
             }
         }
 
-        private string GetGameVersion(List<string> versions, object aliases)
+        private string GetGameVersion(List<string> versions, Dictionary<string, string[]> aliases)
         {
             string version = Utils.GetVersion();
             if (!string.IsNullOrEmpty(version) && versions.Contains(version))
@@ -190,25 +190,21 @@ namespace ModAssistant
             return versions[0];
         }
 
-        private string CheckAliases(List<string> versions, object aliases, string detectedVersion)
+        private string CheckAliases(List<string> versions, Dictionary<string, string[]> aliasesDict, string detectedVersion)
         {
-            Dictionary<string, object> Objects = (Dictionary<string, object>)aliases;
+            Dictionary<string, List<string>> aliases = aliasesDict.ToDictionary(x => x.Key, x => x.Value.ToList());
             foreach (string version in versions)
             {
-                object x;
-                if (Objects.TryGetValue(version, out x))
+                if (aliases.TryGetValue(version, out var x))
                 {
-                    object[] aliasArray = (object[])x;
-                    foreach (object alias in aliasArray)
+                    if (x.Contains(detectedVersion))
                     {
-                        if (alias.ToString() == detectedVersion)
-                        {
-                            GameVersionOverride = detectedVersion;
-                            return version;
-                        }
+                        GameVersionOverride = detectedVersion;
+                        return version;
                     }
                 }
             }
+
             return string.Empty;
         }
 

--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -195,13 +195,17 @@ namespace ModAssistant
             Dictionary<string, object> Objects = (Dictionary<string, object>)aliases;
             foreach (string version in versions)
             {
-                object[] aliasArray = (object[])Objects[version];
-                foreach (object alias in aliasArray)
+                object x;
+                if (Objects.TryGetValue(version, out x))
                 {
-                    if (alias.ToString() == detectedVersion)
+                    object[] aliasArray = (object[])x;
+                    foreach (object alias in aliasArray)
                     {
-                        GameVersionOverride = detectedVersion;
-                        return version;
+                        if (alias.ToString() == detectedVersion)
+                        {
+                            GameVersionOverride = detectedVersion;
+                            return version;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A quick hotglue fix for the Issue #239 
Seemed like the code threw an error when the version key wasn't found in the dictionary, so I did a silent if-statement to pass any versions that doesn't match the current one.