### PR TITLE
Add informative text for versions with no updated mods

### DIFF
--- a/ModAssistant/Localisation/de.xaml
+++ b/ModAssistant/Localisation/de.xaml
@@ -93,6 +93,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Prüfe installierte Mods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Lade Mods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Laden der Mods abgeschlossen</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">Installiere {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">{0} installiert</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Mod Installation abgeschlossen</sys:String>

--- a/ModAssistant/Localisation/en-DEBUG.xaml
+++ b/ModAssistant/Localisation/en-DEBUG.xaml
@@ -62,6 +62,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Mods:CheckingInstalledMods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Mods:LoadingMods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Mods:FinishedLoadingMods</sys:String>
+    <sys:String x:Key="Mods:NoMods">Mods:NoMods</sys:String>
     <sys:String x:Key="Mods:InstallingMod">{0} Mods:InstallingMod</sys:String>
     <sys:String x:Key="Mods:InstalledMod">{0} Mods:InstalledMod</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Mods:FinishedInstallingMods</sys:String>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -93,6 +93,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Checking installed mods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Loading Mods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Finished loading mods</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods detected for this version of Beat Saber</sys:String>
     <sys:String x:Key="Mods:InstallingMod">Installing {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">Installed {0}</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Finished installing mods</sys:String>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -93,7 +93,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Checking installed mods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Loading Mods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Finished loading mods</sys:String>
-    <sys:String x:Key="Mods:NoMods">No mods detected for this version of Beat Saber</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String>
     <sys:String x:Key="Mods:InstallingMod">Installing {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">Installed {0}</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Finished installing mods</sys:String>

--- a/ModAssistant/Localisation/fr.xaml
+++ b/ModAssistant/Localisation/fr.xaml
@@ -98,6 +98,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Vérification des mods installés</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Chargement des mods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Fin : mods chargés</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">Installation de {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">{0} installé</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Fin : mods installés</sys:String>

--- a/ModAssistant/Localisation/it.xaml
+++ b/ModAssistant/Localisation/it.xaml
@@ -93,6 +93,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Controllo le mod installate</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Carico le mod</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Caricamento delle mod completato</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">Installazione di {0} in corso</sys:String>
     <sys:String x:Key="Mods:InstalledMod">{0} installato</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Installazione delle mod completata</sys:String>

--- a/ModAssistant/Localisation/ko.xaml
+++ b/ModAssistant/Localisation/ko.xaml
@@ -92,6 +92,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">설치된 모드들을 확인하고 있습니다</sys:String>
     <sys:String x:Key="Mods:LoadingMods">모드들을 불러오고 있습니다</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">모드들을 불러왔습니다</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">Installing {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">Installed {0}</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">모드 설치를 마쳤습니다</sys:String>

--- a/ModAssistant/Localisation/nl.xaml
+++ b/ModAssistant/Localisation/nl.xaml
@@ -91,6 +91,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Geïnstalleerde mods controleren</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Mods Laden</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Klaar met mods laden</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">{0} wordt geïnstalleerd</sys:String>
     <sys:String x:Key="Mods:InstalledMod">{0} is geïnstalleerd</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Klaar met mods installeren</sys:String>

--- a/ModAssistant/Localisation/ru.xaml
+++ b/ModAssistant/Localisation/ru.xaml
@@ -93,6 +93,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Проверка установленных модификаций</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Загрузка модификаций</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Загрузка модификаций окончена</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">Установка {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">Установлено {0}</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Установка модификаций окончена.</sys:String>

--- a/ModAssistant/Localisation/sv.xaml
+++ b/ModAssistant/Localisation/sv.xaml
@@ -93,6 +93,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">Kollar efter installerade mods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Laddar Mods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Mods färdigladdade!</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">Installerar {0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">Installerat {0}</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Mods färdiginstallerade!</sys:String>

--- a/ModAssistant/Localisation/zh.xaml
+++ b/ModAssistant/Localisation/zh.xaml
@@ -89,6 +89,7 @@
     <sys:String x:Key="Mods:CheckingInstalledMods">正在检查已安装的Mod</sys:String>
     <sys:String x:Key="Mods:LoadingMods">正在加载Mod列表</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Mod列表加载完成</sys:String>
+    <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String> <!-- NEEDS TRANSLATING -->
     <sys:String x:Key="Mods:InstallingMod">正在安装{0}</sys:String>
     <sys:String x:Key="Mods:InstalledMod">已安装{0}</sys:String>
     <sys:String x:Key="Mods:FinishedInstallingMods">Mod安装完成</sys:String>

--- a/ModAssistant/Pages/Mods.xaml
+++ b/ModAssistant/Pages/Mods.xaml
@@ -12,126 +12,135 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <TextBlock
-            Name="SearchText"
-            Padding="5,0,0,0"
-            Height="0"
-            Grid.Row="0"
-            Text="{DynamicResource Mods:SearchLabel}"
-            Panel.ZIndex="1"
-            Foreground="{DynamicResource TextColor}"
-            Background="{DynamicResource BottomStatusBarBackground}" />
-        <TextBox
-            Name="SearchBar"
-            Margin="0,-1,0,0"
-            Padding="3,1,0,0"
-            Height="0"
-            Grid.Row="0"
-            Panel.ZIndex="2"
-            Background="#00000000"
-            Foreground="{DynamicResource TextColor}"
-            TextChanged="SearchBar_TextChanged"
-            BorderThickness="0" />
-        <ListView
-            Name="ModsListView"
-            Grid.Column="1"
-            Grid.Row="1"
-            SelectionChanged="ModsListView_SelectionChanged"
-            SelectionMode="Single">
-            <ListView.View>
-                <GridView>
-                    <GridView.Columns>
-                        <GridViewColumn Width="30">
-                            <GridViewColumn.Header>
-                                <Button
-                                    Name="SearchButton"
-                                    Background="#00000000"
-                                    BorderThickness="0"
-                                    Click="SearchButton_Click"
-                                    Padding="9,-1,9,0"
-                                    Margin="-5"
-                                    Content="🔍"
-                                    FontSize="11" />
-                            </GridViewColumn.Header>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <CheckBox
-                                        Name="ModCheckBox"
-                                        Checked="ModCheckBox_Checked"
-                                        IsChecked="{Binding Path=IsSelected, Mode=TwoWay}"
-                                        IsEnabled="{Binding IsEnabled}"
-                                        Tag="{Binding ModInfo}"
-                                        Unchecked="ModCheckBox_Unchecked" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn DisplayMemberBinding="{Binding ModName}" Header="{DynamicResource Mods:Header:Name}" />
+        <Grid x:Name="NoModsGrid" Visibility="Visible">
+            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32" FontWeight="SemiBold">
+                <TextBlock Text="{DynamicResource Mods:NoMods}" />.
+            </TextBlock>
+        </Grid>
 
-                        <GridViewColumn x:Name="InstalledColumn" Header="{DynamicResource Mods:Header:Installed}">
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <TextBlock
-                                        Foreground="{Binding GetVersionColor}"
-                                        Text="{Binding InstalledVersion}"
-                                        TextDecorations="{Binding GetVersionDecoration}" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
+        <Grid Visibility="Hidden">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-                        <GridViewColumn DisplayMemberBinding="{Binding ModVersion}" Header="{DynamicResource Mods:Header:Latest}" />
-                        <GridViewColumn x:Name="DescriptionColumn" Header="{DynamicResource Mods:Header:Description}">
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Margin="{Binding PromotionMargin}">
-                                            <Hyperlink NavigateUri="{Binding PromotionLink, TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
-                                                <Run Text="{Binding PromotionText}" />
-                                            </Hyperlink>
-                                        </TextBlock>
-                                        <TextBlock Text="{Binding ModDescription}" MouseLeftButtonDown="CopyText" />
-                                    </StackPanel>
-                                </DataTemplate>
-
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-
-                        <GridViewColumn
-                            x:Name="UninstallColumn"
-                            Width="70"
-                            Header="{DynamicResource Mods:Header:Uninstall}">
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
+            <TextBlock
+                Name="SearchText"
+                Grid.Row="0"
+                Height="0"
+                Padding="5,0,0,0"
+                Panel.ZIndex="1"
+                Background="{DynamicResource BottomStatusBarBackground}"
+                Foreground="{DynamicResource TextColor}"
+                Text="{DynamicResource Mods:SearchLabel}" />
+            <TextBox
+                Name="SearchBar"
+                Grid.Row="0"
+                Height="0"
+                Margin="0,-1,0,0"
+                Padding="3,1,0,0"
+                Panel.ZIndex="2"
+                Background="#00000000"
+                BorderThickness="0"
+                Foreground="{DynamicResource TextColor}"
+                TextChanged="SearchBar_TextChanged" />
+            <ListView
+                Name="ModsListView"
+                Grid.Row="1"
+                Grid.Column="1"
+                SelectionChanged="ModsListView_SelectionChanged"
+                SelectionMode="Single">
+                <ListView.View>
+                    <GridView>
+                        <GridView.Columns>
+                            <GridViewColumn Width="30">
+                                <GridViewColumn.Header>
                                     <Button
-                                        Name="Uninstall"
-                                        Click="Uninstall_Click"
-                                        Content="{DynamicResource Mods:UninstallButton}"
-                                        Foreground="Red"
-                                        IsEnabled="{Binding CanDelete}"
-                                        Tag="{Binding ModInfo}"
-                                        Visibility="{Binding CanSeeDelete}" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                    </GridView.Columns>
-                </GridView>
-            </ListView.View>
-            <ListView.GroupStyle>
-                <GroupStyle>
-                    <GroupStyle.HeaderTemplate>
-                        <DataTemplate>
-                            <TextBlock
-                                Padding="6,0,0,0"
-                                FontSize="14"
-                                FontWeight="Bold"
-                                Text="{Binding Name}" />
-                        </DataTemplate>
-                    </GroupStyle.HeaderTemplate>
-                </GroupStyle>
-            </ListView.GroupStyle>
-        </ListView>
+                                        Name="SearchButton"
+                                        Margin="-5"
+                                        Padding="9,-1,9,0"
+                                        Background="#00000000"
+                                        BorderThickness="0"
+                                        Click="SearchButton_Click"
+                                        Content="🔍"
+                                        FontSize="11" />
+                                </GridViewColumn.Header>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <CheckBox
+                                            Name="ModCheckBox"
+                                            Checked="ModCheckBox_Checked"
+                                            IsChecked="{Binding Path=IsSelected, Mode=TwoWay}"
+                                            IsEnabled="{Binding IsEnabled}"
+                                            Tag="{Binding ModInfo}"
+                                            Unchecked="ModCheckBox_Unchecked" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn DisplayMemberBinding="{Binding ModName}" Header="{DynamicResource Mods:Header:Name}" />
+
+                            <GridViewColumn x:Name="InstalledColumn" Header="{DynamicResource Mods:Header:Installed}">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock
+                                            Foreground="{Binding GetVersionColor}"
+                                            Text="{Binding InstalledVersion}"
+                                            TextDecorations="{Binding GetVersionDecoration}" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+
+                            <GridViewColumn DisplayMemberBinding="{Binding ModVersion}" Header="{DynamicResource Mods:Header:Latest}" />
+                            <GridViewColumn x:Name="DescriptionColumn" Header="{DynamicResource Mods:Header:Description}">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Margin="{Binding PromotionMargin}">
+                                                <Hyperlink NavigateUri="{Binding PromotionLink, TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
+                                                    <Run Text="{Binding PromotionText}" />
+                                                </Hyperlink>
+                                            </TextBlock>
+                                            <TextBlock MouseLeftButtonDown="CopyText" Text="{Binding ModDescription}" />
+                                        </StackPanel>
+                                    </DataTemplate>
+
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+
+                            <GridViewColumn
+                                x:Name="UninstallColumn"
+                                Width="70"
+                                Header="{DynamicResource Mods:Header:Uninstall}">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Button
+                                            Name="Uninstall"
+                                            Click="Uninstall_Click"
+                                            Content="{DynamicResource Mods:UninstallButton}"
+                                            Foreground="Red"
+                                            IsEnabled="{Binding CanDelete}"
+                                            Tag="{Binding ModInfo}"
+                                            Visibility="{Binding CanSeeDelete}" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView.Columns>
+                    </GridView>
+                </ListView.View>
+                <ListView.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                    Padding="6,0,0,0"
+                                    FontSize="14"
+                                    FontWeight="Bold"
+                                    Text="{Binding Name}" />
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </ListView.GroupStyle>
+            </ListView>
+        </Grid>
     </Grid>
 </Page>

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -136,7 +136,7 @@ namespace ModAssistant.Pages
 
                 RefreshModsList();
                 ModsListView.Visibility = Visibility.Visible;
-                MainWindow.Instance.MainText = $"{FindResource("Mods:FinishedLoadingMods")}.";
+                MainWindow.Instance.MainText = ModList.Count == 0 ? $"{FindResource("Mods:NoMods")}." : $"{FindResource("Mods:FinishedLoadingMods")}.";
 
                 MainWindow.Instance.InstallButton.IsEnabled = true;
                 MainWindow.Instance.GameVersionsBox.IsEnabled = true;

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -135,10 +135,11 @@ namespace ModAssistant.Pages
                 this.DataContext = this;
 
                 RefreshModsList();
-                ModsListView.Visibility = Visibility.Visible;
-                MainWindow.Instance.MainText = ModList.Count == 0 ? $"{FindResource("Mods:NoMods")}." : $"{FindResource("Mods:FinishedLoadingMods")}.";
+                ModsListView.Visibility = ModList.Count == 0 ? Visibility.Hidden : Visibility.Visible;
+                NoModsGrid.Visibility = ModList.Count == 0 ? Visibility.Visible : Visibility.Hidden;
 
-                MainWindow.Instance.InstallButton.IsEnabled = true;
+                MainWindow.Instance.MainText = $"{FindResource("Mods:FinishedLoadingMods")}.";
+                MainWindow.Instance.InstallButton.IsEnabled = ModList.Count != 0;
                 MainWindow.Instance.GameVersionsBox.IsEnabled = true;
             }
             finally


### PR DESCRIPTION
Currently there is no text indicating that no mods were found when there are 0 updated mods on beatmods - only an empty mod list is displayed. This has caused a lot of confusion amongst users who believe this is an issue w/ MA. 

(This fixes #71)