### PR TITLE
Added check and Warning for Uninstalling BSIPA

### DIFF
--- a/ModAssistant/Localisation/de.xaml
+++ b/ModAssistant/Localisation/de.xaml
@@ -104,6 +104,8 @@
     <sys:String x:Key="Mods:FailedExtract">Fehler beim Extrahieren von {0}, neuer Versuch in {1} Sekunden. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Fehler beim Extrahieren von {0} nach {1} Versuchen, wird übersprungen. Dieser Mod funktioniert möglicherweise nicht richtig, also gehe auf eigenes Risiko vor</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Suchen...</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">Über</sys:String>

--- a/ModAssistant/Localisation/en-DEBUG.xaml
+++ b/ModAssistant/Localisation/en-DEBUG.xaml
@@ -73,6 +73,8 @@
     <sys:String x:Key="Mods:FailedExtract">{0} {1} {2} {3} Mods:FailedExtract</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">{0} {1} Mods:FailedExtractMaxReached</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Mods:SearchLabel</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Mods:UninstallBSIPANotFound:Title</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">Mods:UninstallBSIPANotFound:Body</sys:String>
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">About:Title</sys:String>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -104,6 +104,8 @@
     <sys:String x:Key="Mods:FailedExtract">Failed to extract {0}, trying again in {1} seconds. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Failed to extract {0} after max attempts ({1}), skipping. This mod might not work properly so proceed at your own risk</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Search...</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String>
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">About</sys:String>

--- a/ModAssistant/Localisation/fr.xaml
+++ b/ModAssistant/Localisation/fr.xaml
@@ -109,7 +109,8 @@
     <sys:String x:Key="Mods:FailedExtract">Échec de l'extraction de {0}, nouvelle tentative dans {1} secondes. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Échec de l'extraction de {0} après le maximum de tentatives ({1}), abandon. Ce mod pourrait ne pas fonctionner correctement, continuez à vos propres risques</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Recherche...</sys:String>
-
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">À propos</sys:String>

--- a/ModAssistant/Localisation/it.xaml
+++ b/ModAssistant/Localisation/it.xaml
@@ -104,7 +104,9 @@
     <sys:String x:Key="Mods:FailedExtract">Impossibile estrarre {0}, prossimo tentativo in {1} secondi. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Non sono riuscito ad estrarre {0} dopo aver raggiunto il numero massimo di tentativi ({1}), salto questa mod. Questa protrebbe anche non funzionare correttamente, quindi procedi a tuo rischio e pericolo</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Cerca...</sys:String>
-    
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
+
     <!-- About Page -->
     <sys:String x:Key="About:Title">Info</sys:String>
     <sys:String x:Key="About:PageTitle">Info su Mod Assistant</sys:String>

--- a/ModAssistant/Localisation/ko.xaml
+++ b/ModAssistant/Localisation/ko.xaml
@@ -103,6 +103,8 @@
     <sys:String x:Key="Mods:FailedExtract">{0}를 추출하는데 실패했습니다. {1}초 안에 재시도합니다. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">({1})회동안 {0}를 추출하는데 실패했습니다. 이 모드가 제대로 작동하지 않을지도 모릅니다</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Search...</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">정보</sys:String>

--- a/ModAssistant/Localisation/nl.xaml
+++ b/ModAssistant/Localisation/nl.xaml
@@ -102,6 +102,8 @@
     <sys:String x:Key="Mods:FailedExtract">Kon {0} niet uitpakken, probeer opniew over {1} seconden. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Kon {0} niet uitpakken na maximaal aantal pogingen ({1}), deze word nu overgeslagen. Deze mod werkt misschien niet goed dus ga verder op eigen risico</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Zoek...</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">Over</sys:String>

--- a/ModAssistant/Localisation/ru.xaml
+++ b/ModAssistant/Localisation/ru.xaml
@@ -104,8 +104,10 @@
     <sys:String x:Key="Mods:FailedExtract">Не удалось извлечь {0}, попробуйте снова через {1} секунд. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Не удалось извлечь {0} после попыток ({1}), пропускается. Эта модификация может работать некорректно, используйте на свой страх и риск</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Поиск...</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
-  <!-- About Page -->
+    <!-- About Page -->
     <sys:String x:Key="About:Title">Информация</sys:String>
     <sys:String x:Key="About:PageTitle">Про Mod Assistant</sys:String>
     <sys:String x:Key="About:List:Header">Я ассистент, и я создал Mod Assistant для помощи модификациям с некоторыми личными принципами:</sys:String>

--- a/ModAssistant/Localisation/sv.xaml
+++ b/ModAssistant/Localisation/sv.xaml
@@ -104,6 +104,8 @@
     <sys:String x:Key="Mods:FailedExtract">Extrahering misslyckades {0}, försöker igen om {1} sekunder. ({2}/{3})</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">Misslyckades med att extrahera {0} efter maxantalet försök ({1}), hoppar över. Denna mod kanske inte fungerar som den ska så fortsätt på egen risk.</sys:String>
     <sys:String x:Key="Mods:SearchLabel">Sök...</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">Om</sys:String>

--- a/ModAssistant/Localisation/zh.xaml
+++ b/ModAssistant/Localisation/zh.xaml
@@ -103,6 +103,8 @@
     <sys:String x:Key="Mods:FailedExtract">{0}解压失败，将在{1}秒后重试。（{2}/{3}）</sys:String>
     <sys:String x:Key="Mods:FailedExtractMaxReached">{0}在重试{1}次后仍然无法解压，将被跳过。注意，这个Mod可能无法使用。</sys:String>
     <sys:String x:Key="Mods:SearchLabel">搜索...</sys:String>
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Title">Failed to Uninstall BSIPA</sys:String> <!-- NEEDS TRANSLATING -->
+    <sys:String x:Key="Mods:UninstallBSIPANotFound:Body">BSIPA installation not found, uninstall operation skipped.</sys:String> <!-- NEEDS TRANSLATING -->
 
     <!-- About Page -->
     <sys:String x:Key="About:Title">关于</sys:String>

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -693,8 +693,11 @@ namespace ModAssistant.Pages
                     break;
                 }
             }
-            if (mod.name.ToLower() == "bsipa") { 
-                if (Directory.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA")) & File.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA.exe"))){
+            if (mod.name.ToLower() == "bsipa") {
+                var hasIPAExe = File.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA.exe"));
+                var hasIPADir = Directory.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA"));
+
+                if (hasIPADir && hasIPAExe){
                     UninstallBSIPA(links);
                 }
                 else

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -694,7 +694,7 @@ namespace ModAssistant.Pages
                 }
             }
             if (mod.name.ToLower() == "bsipa") { 
-                if (Directory.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA")) & File.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA.exe"){
+                if (Directory.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA")) & File.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA.exe"))){
                     UninstallBSIPA(links);
                 }
                 else

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -693,8 +693,15 @@ namespace ModAssistant.Pages
                     break;
                 }
             }
-            if (mod.name.ToLower() == "bsipa")
-                UninstallBSIPA(links);
+            if (mod.name.ToLower() == "bsipa") { 
+                if (Directory.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA")) & File.Exists(Path.Combine(App.BeatSaberInstallDirectory, "IPA.exe"){
+                    UninstallBSIPA(links);
+                }
+                else
+                {
+                    System.Windows.Forms.MessageBox.Show("BSIPA was not uninstalled as it was not found.", "Failed to uninstall BSIPA.", MessageBoxButtons.OK,MessageBoxIcon.Warning);
+                }
+            }
             foreach (Mod.FileHashes files in links.hashMd5)
             {
                 if (File.Exists(Path.Combine(App.BeatSaberInstallDirectory, files.file)))

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -702,7 +702,10 @@ namespace ModAssistant.Pages
                 }
                 else
                 {
-                    System.Windows.Forms.MessageBox.Show("BSIPA was not uninstalled as it was not found.", "Failed to uninstall BSIPA.", MessageBoxButtons.OK,MessageBoxIcon.Warning);
+                    var title = (string)FindResource("Mods:UninstallBSIPANotFound:Title");
+                    var body = (string)FindResource("Mods:UninstallBSIPANotFound:Body");
+
+                    System.Windows.Forms.MessageBox.Show(body, title, MessageBoxButtons.OK,MessageBoxIcon.Warning);
                 }
             }
             foreach (Mod.FileHashes files in links.hashMd5)


### PR DESCRIPTION
Simple check if IPA.exe and IPA Directory exists before trying to delete it. This should prevent crashes. Closes #72