### PR TITLE
Update promos

### DIFF
--- a/ModAssistant/Classes/Promotions.cs
+++ b/ModAssistant/Classes/Promotions.cs
@@ -1,3 +1,5 @@
+﻿using System.Collections.Generic;
+
 namespace ModAssistant
 {
     class Promotions
@@ -7,8 +9,11 @@ namespace ModAssistant
             new Promotion
             {
                 ModName = "YUR Fit Calorie Tracker",
-                Text = "Join our Discord!",
-                Link = "https://yur.chat"
+                Links = new List<PromotionLink>(){
+                    new PromotionLink{Text = "Join our Discord!", Link = "https://yur.chat", TextAfterLink = " Or find us on "},
+                    new PromotionLink{Text = "iOS", Link = "https://y.at/💣🍑📱", TextAfterLink = " and " },
+                    new PromotionLink{Text = "Android", Link = "https://y.at/💾🔬📡💻📱", TextAfterLink = "!" }
+                },
             }
         };
     }
@@ -16,7 +21,13 @@ namespace ModAssistant
     class Promotion
     {
         public string ModName;
+        public List<PromotionLink> Links;
+    }
+
+    class PromotionLink
+    {
         public string Text;
         public string Link;
+        public string TextAfterLink;
     }
 }

--- a/ModAssistant/Pages/Mods.xaml
+++ b/ModAssistant/Pages/Mods.xaml
@@ -95,24 +95,24 @@
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Margin="{Binding PromotionMargin}">
+                                            <TextBlock Margin="{Binding PromotionMargin}" Padding="0">
 		                                        <Hyperlink NavigateUri="{Binding PromotionLinks[0], TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
 			                                        <Run Text="{Binding PromotionTexts[0]}" />
 		                                        </Hyperlink>
                                                 
-	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[0]}" />
+	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[0]}" Padding="0" Margin="0" />
 		
 		                                        <Hyperlink NavigateUri="{Binding PromotionLinks[1], TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
 			                                        <Run Text="{Binding PromotionTexts[1]}" />
 		                                        </Hyperlink>
                                                 
-	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[1]}" />
+	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[1]}" Padding="0" Margin="0" />
 		
 		                                        <Hyperlink NavigateUri="{Binding PromotionLinks[2], TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
 			                                        <Run Text="{Binding PromotionTexts[2]}" />
 		                                        </Hyperlink>
                                                 
-	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[2]}" />
+	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[2]}" Padding="0" Margin="0" />
 		
 	                                        </TextBlock>
                                             <TextBlock MouseLeftButtonDown="CopyText" Text="{Binding ModDescription}" />

--- a/ModAssistant/Pages/Mods.xaml
+++ b/ModAssistant/Pages/Mods.xaml
@@ -96,10 +96,25 @@
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Margin="{Binding PromotionMargin}">
-                                                <Hyperlink NavigateUri="{Binding PromotionLink, TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
-                                                    <Run Text="{Binding PromotionText}" />
-                                                </Hyperlink>
-                                            </TextBlock>
+		                                        <Hyperlink NavigateUri="{Binding PromotionLinks[0], TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
+			                                        <Run Text="{Binding PromotionTexts[0]}" />
+		                                        </Hyperlink>
+                                                
+	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[0]}" />
+		
+		                                        <Hyperlink NavigateUri="{Binding PromotionLinks[1], TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
+			                                        <Run Text="{Binding PromotionTexts[1]}" />
+		                                        </Hyperlink>
+                                                
+	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[1]}" />
+		
+		                                        <Hyperlink NavigateUri="{Binding PromotionLinks[2], TargetNullValue=about:blank}" RequestNavigate="Hyperlink_RequestNavigate">
+			                                        <Run Text="{Binding PromotionTexts[2]}" />
+		                                        </Hyperlink>
+                                                
+	                                            <TextBlock Text="{Binding PromotionTextAfterLinks[2]}" />
+		
+	                                        </TextBlock>
                                             <TextBlock MouseLeftButtonDown="CopyText" Text="{Binding ModDescription}" />
                                         </StackPanel>
                                     </DataTemplate>

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -285,8 +285,17 @@ namespace ModAssistant.Pages
                 {
                     if (mod.name == promo.ModName)
                     {
-                        ListItem.PromotionText = promo.Text;
-                        ListItem.PromotionLink = promo.Link;
+                        ListItem.PromotionTexts = new string[promo.Links.Count];
+                        ListItem.PromotionLinks = new string[promo.Links.Count];
+                        ListItem.PromotionTextAfterLinks = new string[promo.Links.Count];
+
+                        for (int i = 0; i < promo.Links.Count; ++i)
+                        {
+                            PromotionLink link = promo.Links[i];
+                            ListItem.PromotionTexts[i] = link.Text;
+                            ListItem.PromotionLinks[i] = link.Link;
+                            ListItem.PromotionTextAfterLinks[i] = link.TextAfterLink;
+                        }
                     }
                 }
 
@@ -609,13 +618,14 @@ namespace ModAssistant.Pages
                 }
             }
 
-            public string PromotionText { get; set; }
-            public string PromotionLink { get; set; }
+            public string[] PromotionTexts { get; set; }
+            public string[] PromotionLinks { get; set; }
+            public string[] PromotionTextAfterLinks { get; set; }
             public string PromotionMargin
             {
                 get
                 {
-                    if (string.IsNullOrEmpty(PromotionText)) return "0";
+                    if  (PromotionTexts == null || string.IsNullOrEmpty(PromotionTexts[0])) return "0";
                     return "0,0,5,0";
                 }
             }

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -625,7 +625,7 @@ namespace ModAssistant.Pages
             {
                 get
                 {
-                    if  (PromotionTexts == null || string.IsNullOrEmpty(PromotionTexts[0])) return "0";
+                    if  (PromotionTexts == null || string.IsNullOrEmpty(PromotionTexts[0])) return "-15,0,0,0";
                     return "0,0,5,0";
                 }
             }


### PR DESCRIPTION
Updated promos logic to allow for up to 3 links per promo, and updated the YUR promo for the new format.

Screenshot:
![image](https://user-images.githubusercontent.com/27714637/117588926-76a84e00-b0db-11eb-9d30-e00fad72fe58.png)

This implementation is a bit gross, but this is the best way I could get this to work correctly.

In the future it may be worth using a more elegant solution, but it doesn't seem like this type of styling is easy to dynamically generate in this situation. My knowledge of WPF is limited, so there may be an easier way to do this that I've overlooked.

## Before anyone tries to go down that rabbit hole like I did, here's what I tried:

***Access the mod's StackPanel directly to inject the promo elements when needed***
It is possible to find elements by name using `rootElementName.FindName("nameToFind")`, but the element would need a unique name in the list.
Unfortunately, [it is not possible to set the name programmatically through xaml,](https://stackoverflow.com/a/5509236) such as with ` Name="{Binding ModName}"` .
I think this would be possible if the xaml for the list were generated from the C# code, but it would require reworking a lot of MA.

***Using a different WPF element other than TextBlock***
Using a different element still runs into the same issue as above, and the hyperlinks would still need to be their own child elements.