### PR TITLE
Fixed GameVersion detection

### DIFF
--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -235,19 +235,35 @@ namespace ModAssistant
         public static string GetVersion()
         {
             string filename = Path.Combine(App.BeatSaberInstallDirectory, "Beat Saber_Data", "globalgamemanagers");
-            using (FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            using (var stream = File.OpenRead(filename))
+            using (var reader = new BinaryReader(stream, Encoding.UTF8))
             {
-                byte[] file = File.ReadAllBytes(filename);
-                byte[] bytes = new byte[32];
+                const string key = "public.app-category.games";
+                int pos = 0;
 
-                fs.Read(file, 0, Convert.ToInt32(fs.Length));
-                fs.Close();
-                int index = Encoding.UTF8.GetString(file).IndexOf("public.app-category.games") + 136;
+                while (stream.Position < stream.Length && pos < key.Length)
+                {
+                    if (reader.ReadByte() == key[pos]) pos++;
+                    else pos = 0;
+                }
 
-                Array.Copy(file, index, bytes, 0, 32);
-                string version = Encoding.UTF8.GetString(bytes).Trim(Constants.IllegalCharacters);
+                if (stream.Position == stream.Length) // we went through the entire stream without finding the key
+                    throw new KeyNotFoundException("Could not find key '" + key + "' in " + filename);
 
-                return version;
+                while (stream.Position < stream.Length)
+                {
+                    var current = (char)reader.ReadByte();
+                    if (char.IsDigit(current))
+                        break;
+                }
+
+                var rewind = -sizeof(int) - sizeof(byte);
+                stream.Seek(rewind, SeekOrigin.Current); // rewind to the string length
+
+                var strlen = reader.ReadInt32();
+                var strbytes = reader.ReadBytes(strlen);
+
+                return Encoding.UTF8.GetString(strbytes);
             }
         }
 


### PR DESCRIPTION
Before this fix, the method would return version "1.1" instead of "1.15.0" for example.
The code is pretty much [borrowed from BSIPA](https://github.com/bsmg/BeatSaber-IPA-Reloaded/blob/c8457908b49a9582691c50117a622ec951f712b0/IPA.Injector/GameVersionEarly.cs#L24-L58) as we fixed it in there shortly after the 1.12 update.

The only thing I'm not really sure of is whether we should return `null` or throw the `KeyNotFoundException` on line 251