### PR TITLE
Add integrity check before file extraction

### DIFF
--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -119,6 +119,15 @@ namespace ModAssistant
             }
         }
 
+        public static string CalculateMD5FromStream(Stream stream)
+        {
+            using (var md5 = MD5.Create())
+            {
+                var hash = md5.ComputeHash(stream);
+                return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+            }
+        }
+
         public static string GetInstallDir()
         {
             string InstallDir = Properties.Settings.Default.InstallFolder;

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -393,10 +393,12 @@ namespace ModAssistant.Pages
                 return;
             }
 
-            List<ZipArchiveEntry> files = new List<ZipArchiveEntry>(filesCount);
+            List<ZipArchiveEntry> files;
 
             do
             {
+                files = new List<ZipArchiveEntry>(filesCount);
+
                 using (Stream stream = await DownloadMod(Utils.Constants.BeatModsURL + downloadLink))
                 using (ZipArchive archive = new ZipArchive(stream))
                 {

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -368,10 +368,13 @@ namespace ModAssistant.Pages
 
         private async Task InstallMod(Mod mod, string directory)
         {
+            int filesCount = 0;
             string downloadLink = null;
 
             foreach (Mod.DownloadLink link in mod.downloads)
             {
+                filesCount = link.hashMd5.Length;
+
                 if (link.type == "universal")
                 {
                     downloadLink = link.url;
@@ -390,6 +393,8 @@ namespace ModAssistant.Pages
                 return;
             }
 
+            List<ZipArchiveEntry> files = new List<ZipArchiveEntry>(filesCount);
+
             using (Stream stream = await DownloadMod(Utils.Constants.BeatModsURL + downloadLink))
             using (ZipArchive archive = new ZipArchive(stream))
             {
@@ -403,8 +408,29 @@ namespace ModAssistant.Pages
 
                     if (!string.IsNullOrEmpty(file.Name))
                     {
-                        await ExtractFile(file, Path.Combine(directory, file.FullName), 3.0, mod.name, 10);
+                        foreach (Mod.DownloadLink download in mod.downloads)
+                        {
+                            foreach (Mod.FileHashes fileHash in download.hashMd5)
+                            {
+                                if (fileHash.hash == Utils.CalculateMD5FromStream(file.Open()))
+                                {
+                                    files.Add(file);
+                                    break;
+                                }
+                            }
+                        }
                     }
+                }
+
+                if (files.Count != filesCount)
+                {
+                    _ = Task.Run(async () => await InstallMod(mod, directory));
+                    return;
+                }
+
+                foreach (ZipArchiveEntry file in files)
+                {
+                    await ExtractFile(file, Path.Combine(directory, file.FullName), 3.0, mod.name, 10);
                 }
             }
 
@@ -625,7 +651,7 @@ namespace ModAssistant.Pages
             {
                 get
                 {
-                    if  (PromotionTexts == null || string.IsNullOrEmpty(PromotionTexts[0])) return "-15,0,0,0";
+                    if (PromotionTexts == null || string.IsNullOrEmpty(PromotionTexts[0])) return "-15,0,0,0";
                     return "0,0,5,0";
                 }
             }


### PR DESCRIPTION
This adds an integrity check before extracting the archives downloaded from BeatMods. If the integrity check isn't passed, then we don't extract anything and just redownload the mod again. Tell me if you see any issues.