### PR TITLE
Fix libraries detection

### DIFF
--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -28,6 +28,7 @@ namespace ModAssistant.Pages
         public Mod[] ModsList;
         public Mod[] AllModsList;
         public static List<Mod> InstalledMods = new List<Mod>();
+        public static List<Mod> ManifestsToMatch = new List<Mod>();
         public List<string> CategoryNames = new List<string>();
         public CollectionView view;
         public bool PendingChanges;
@@ -175,12 +176,28 @@ namespace ModAssistant.Pages
 
             foreach (string file in Directory.GetFileSystemEntries(Path.Combine(App.BeatSaberInstallDirectory, directory)))
             {
-                if (File.Exists(file) && Path.GetExtension(file) == ".dll" || Path.GetExtension(file) == ".manifest")
+                string fileExtension = Path.GetExtension(file);
+
+                if (File.Exists(file) && (fileExtension == ".dll" || fileExtension == ".manifest"))
                 {
                     Mod mod = GetModFromHash(Utils.CalculateMD5(file));
                     if (mod != null)
                     {
-                        AddDetectedMod(mod);
+                        if (fileExtension == ".manifest")
+                        {
+                            ManifestsToMatch.Add(mod);
+                        }
+                        else
+                        {
+                            if (directory.Contains("Libs"))
+                            {
+                                if (!ManifestsToMatch.Contains(mod)) continue;
+
+                                ManifestsToMatch.Remove(mod);
+                            }
+
+                            AddDetectedMod(mod);
+                        }
                     }
                 }
             }

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -28,7 +28,7 @@ namespace ModAssistant.Pages
         public Mod[] ModsList;
         public Mod[] AllModsList;
         public static List<Mod> InstalledMods = new List<Mod>();
-        public static List<Mod> ManifestsToMatch = new List<Mod>();
+        public static List<Mod> LibsToMatch = new List<Mod>();
         public List<string> CategoryNames = new List<string>();
         public CollectionView view;
         public bool PendingChanges;
@@ -185,15 +185,15 @@ namespace ModAssistant.Pages
                     {
                         if (fileExtension == ".manifest")
                         {
-                            ManifestsToMatch.Add(mod);
+                            LibsToMatch.Add(mod);
                         }
                         else
                         {
                             if (directory.Contains("Libs"))
                             {
-                                if (!ManifestsToMatch.Contains(mod)) continue;
+                                if (!LibsToMatch.Contains(mod)) continue;
 
-                                ManifestsToMatch.Remove(mod);
+                                LibsToMatch.Remove(mod);
                             }
 
                             AddDetectedMod(mod);


### PR DESCRIPTION
This ensures that MA will detect an installed library only if both the `.manifest` and the `.dll` were found. As it is now, it is checking both separately, and will still add the library if either of them is found.

This solves an issue that can happen if you have clean installed your game, and copied your old Plugins folder with the manifests into your new installation. MA thinks the libraries are installed, while they don't exist in `Libs\`. This can also *maybe* solve the Ini Parser issue that happens sometimes.