### PR TITLE
Added ModelDownloader to the default mods list to go along with BeatSaverDownloader

### DIFF
--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -24,7 +24,7 @@ namespace ModAssistant.Pages
     {
         public static Mods Instance = new Mods();
 
-        public List<string> DefaultMods = new List<string>() { "SongCore", "ScoreSaber", "BeatSaverDownloader", "BeatSaverVoting", "PlaylistCore", "Survey" };
+        public List<string> DefaultMods = new List<string>() { "SongCore", "ScoreSaber", "BeatSaverDownloader", "BeatSaverVoting", "PlaylistCore", "Survey", "ModelDownloader" };
         public Mod[] ModsList;
         public Mod[] AllModsList;
         public static List<Mod> InstalledMods = new List<Mod>();


### PR DESCRIPTION
Since BeatSaverDownloader is checked by default, I think it would make sense to have ModelDownloader as a default mod too.

This PR simply adds `ModelDownloader` to the `DefaultMods` List in` Mods.xaml.cs`