### PR TITLE
Removed scoresaber from default mods

### DIFF
--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -24,7 +24,7 @@ namespace ModAssistant.Pages
     {
         public static Mods Instance = new Mods();
 
-        public List<string> DefaultMods = new List<string>() { "SongCore", "ScoreSaber", "BeatSaverDownloader", "BeatSaverVoting", "PlaylistManager", "ModelDownloader" };
+        public List<string> DefaultMods = new List<string>() { "SongCore", "BeatSaverDownloader", "BeatSaverVoting", "PlaylistManager", "ModelDownloader" };
         public Mod[] ModsList;
         public Mod[] AllModsList;
         public static List<Mod> InstalledMods = new List<Mod>();


### PR DESCRIPTION
When scoresaber is unreachable for any reason, songs don't load. Which requires either waiting for it to become available again or simply uninstall the mod. Though next time opening ModAssistant it is ticked by default. Please make this opt-in instead of having to opt-out every time ModAssistant is launched.