### PR TITLE
On OneClick save WIP song to CustomWIPLevels directory

### DIFF
--- a/ModAssistant/Classes/External Interfaces/BeatSaver.cs
+++ b/ModAssistant/Classes/External Interfaces/BeatSaver.cs
@@ -16,6 +16,7 @@ namespace ModAssistant.API
     {
         private const string BeatSaverURLPrefix = "https://api.beatsaver.com";
         private static readonly string CustomSongsFolder = Path.Combine("Beat Saber_Data", "CustomLevels");
+        private static readonly string CustomWIPSongsFolder = Path.Combine("Beat Saber_Data", "CustomWIPLevels");
         private const bool BypassDownloadCounter = false;
 
         public static async Task<BeatSaverMap> GetFromKey(string Key, bool showNotification = true)
@@ -139,19 +140,23 @@ namespace ModAssistant.API
                 throw new Exception("Could not find map version.");
             }
 
-            string zip = Path.Combine(Utils.BeatSaberPath, CustomSongsFolder, Map.HashToDownload) + ".zip";
+            string state = responseMap.versions[0].state;
+            string targetSongDirectory = state.Equals("Published") ? CustomSongsFolder : CustomWIPSongsFolder;
+
+            string zip = Path.Combine(Utils.BeatSaberPath, targetSongDirectory, Map.HashToDownload) + ".zip";
             string mapName = string.Concat(($"{responseMap.id} ({responseMap.metadata.songName} - {responseMap.metadata.levelAuthorName})")
                              .Split(ModAssistant.Utils.Constants.IllegalCharacters));
-            string directory = Path.Combine(Utils.BeatSaberPath, CustomSongsFolder, mapName);
+
+            string directory = Path.Combine(Utils.BeatSaberPath, targetSongDirectory, mapName);
 
 #pragma warning disable CS0162 // Unreachable code detected
             if (BypassDownloadCounter)
             {
-                await Utils.DownloadAsset(mapVersion.downloadURL, CustomSongsFolder, Map.HashToDownload + ".zip", mapName, showNotification, true);
+                await Utils.DownloadAsset(mapVersion.downloadURL, targetSongDirectory, Map.HashToDownload + ".zip", mapName, showNotification, true);
             }
             else
             {
-                await Utils.DownloadAsset(mapVersion.downloadURL, CustomSongsFolder, Map.HashToDownload + ".zip", mapName, showNotification, true);
+                await Utils.DownloadAsset(mapVersion.downloadURL, targetSongDirectory, Map.HashToDownload + ".zip", mapName, showNotification, true);
             }
 #pragma warning restore CS0162 // Unreachable code detected
 


### PR DESCRIPTION
Since people can now download WIP (not published) songs by a direct id, it creates several issues like:
- WIP songs are saved in the same folder as regular songs, so they are mixed together
- a user can still launch the map and create a new leaderboard on ScoreSaber when only the Practice button is usually enabled for WIP songs

This request is based on a version state data and may be rejected if BeatSaver will provide a separated link for WIP maps so it will be process more clearly by OneClick.