### PR TITLE
Prompt to install previous versions after a game update

### DIFF
--- a/ModAssistant/Localisation/en-DEBUG.xaml
+++ b/ModAssistant/Localisation/en-DEBUG.xaml
@@ -60,6 +60,12 @@
     <sys:String x:Key="Mods:UninstallButton">Mods:UninstallButton</sys:String>
     <sys:String x:Key="Mods:LoadFailed">Mods:LoadFailed</sys:String>
     <sys:String x:Key="Mods:CheckingInstalledMods">Mods:CheckingInstalledMods</sys:String>
+    <sys:String x:Key="Mods:GameUpdatedPrompt:Title">Mods:GameUpdatedPrompt:Title</sys:String>
+    <sys:String x:Key="Mods:GameUpdatedPrompt:OkCancel">Mods:GameUpdatedPrompt:OkCancel</sys:String>
+    <sys:String x:Key="Mods:FailedToSelect:Title">Mods:FailedToSelect:Title</sys:String>
+    <sys:String x:Key="Mods:FailedToSelect:Body1">Mods:FailedToSelect:Body1</sys:String>
+    <sys:String x:Key="Mods:FailedToSelect:Body2">Mods:FailedToSelect:Body2</sys:String>
+    <sys:String x:Key="Mods:CheckingPreviousMods">Mods:CheckingPreviousMods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Mods:LoadingMods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Mods:FinishedLoadingMods</sys:String>
     <sys:String x:Key="Mods:NoMods">Mods:NoMods</sys:String>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -91,6 +91,12 @@
     <sys:String x:Key="Mods:UninstallButton">Uninstall</sys:String>
     <sys:String x:Key="Mods:LoadFailed">Could not load mods list</sys:String>
     <sys:String x:Key="Mods:CheckingInstalledMods">Checking installed mods</sys:String>
+    <sys:String x:Key="Mods:GameUpdatedPrompt:Title">Reselect mods?</sys:String>
+    <sys:String x:Key="Mods:GameUpdatedPrompt:OkCancel">The game has updated since you last modded, would you like to automatically re-select the mods you had installed previously?</sys:String>
+    <sys:String x:Key="Mods:FailedToSelect:Title">Failed to select {0} mods</sys:String>
+    <sys:String x:Key="Mods:FailedToSelect:Body1">The following mods could not be found and weren't selected:</sys:String>
+    <sys:String x:Key="Mods:FailedToSelect:Body2">These mods might not be updated for the current game version.</sys:String>
+    <sys:String x:Key="Mods:CheckingPreviousMods">Checking previously installed mods</sys:String>
     <sys:String x:Key="Mods:LoadingMods">Loading Mods</sys:String>
     <sys:String x:Key="Mods:FinishedLoadingMods">Finished loading mods</sys:String>
     <sys:String x:Key="Mods:NoMods">No mods available for this version of Beat Saber</sys:String>

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -31,8 +31,8 @@ namespace ModAssistant.Pages
         public static List<Mod> InstalledMods = new List<Mod>();
         public static List<Mod> LibsToMatch = new List<Mod>();
         public List<string> CategoryNames = new List<string>();
-        public CollectionView view;
         public static List<string> MissingOldMods = new List<string>();
+        public CollectionView view;
         public bool PendingChanges;
 
         private readonly SemaphoreSlim _modsLoadSem = new SemaphoreSlim(1, 1);
@@ -316,7 +316,6 @@ namespace ModAssistant.Pages
 
         private void AddDetectedMod(Mod mod)
         {
-            Console.WriteLine(mod.name);
             if (!InstalledMods.Contains(mod))
             {
                 InstalledMods.Add(mod);

--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -131,15 +131,23 @@ namespace ModAssistant.Pages
                     !DirectoryContainsMods(Path.Combine(App.BeatSaberInstallDirectory, "Plugins")) &&
                     !DirectoryContainsMods(Path.Combine(App.BeatSaberInstallDirectory, "IPA/Pending/Plugins")))
                 {
-                    var reinstallMods = System.Windows.Forms.MessageBox.Show("The game has updated since you last played, would you like to automatically re-select the mods you had installed previously?", "Reinstall mods?", MessageBoxButtons.OKCancel) == DialogResult.OK;
+                    string body = (string)FindResource("Mods:GameUpdatedPrompt:OkCancel");
+                    string title = (string)FindResource("Mods:GameUpdatedPrompt:Title");
+
+                    var reinstallMods = System.Windows.Forms.MessageBox.Show(body, title, MessageBoxButtons.OKCancel) == DialogResult.OK;
                     if (reinstallMods) {
-                        MainWindow.Instance.MainText = $"Checking mods for previous version of the game...";
+                        MainWindow.Instance.MainText = $"{FindResource("Mods:CheckingPreviousMods")}...";
                         await Task.Run(async () => await SelectPreviousMods(lastModdedVersion));
                         InstalledColumn.Width = double.NaN;
                         UninstallColumn.Width = 70;
                         DescriptionColumn.Width = 750;
-                        
-                        var modsDialog2 = System.Windows.Forms.MessageBox.Show($"The following mods could not be found and weren't selected:\n{string.Join(",\n", MissingOldMods)}\n\nThese mods might not be updated yet.", "Reinstall mods?", MessageBoxButtons.OKCancel) == DialogResult.OK;
+                        if (MissingOldMods.Count > 0) {
+                            string notSelectedTitle = string.Format((string)FindResource("Mods:FailedToSelect:Title"), MissingOldMods.Count);
+                            string notSelectedBody1 = (string)FindResource("Mods:FailedToSelect:Body1");
+                            string notSelectedBody2 = (string)FindResource("Mods:FailedToSelect:Body2");
+
+                            System.Windows.Forms.MessageBox.Show($"{notSelectedBody1}\n{string.Join(",\n", MissingOldMods)}\n\n{notSelectedBody2}", notSelectedTitle, MessageBoxButtons.OK);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Some users have communicated displeasures with having to track down and re-select all of their mods after a game update, and this feature should fix that in a way that the current `Save Selected Mods` option can't.

- Specifically tells you which of the user's mods aren't updated yet.
- Gives the user a choice of whether or not to select old mods.
- Works with mods not installed through Mod Assistant as long as they're on BeatMods.

I'd like to look into a few more things before merging this, though:
- [x] Basic feature
- [x] Localization support
- [ ] Option to disable the feature 
- [ ] A more descriptive message when not all of the user's mods are updated 
- [ ] Look into viability of a "Not Updated" section directly in the mod list to give a visual indicator that MA isn't broken, the mods just aren't updated
