### PR TITLE
Name downloaded playlists by Content-Disposition

### DIFF
--- a/ModAssistant/Classes/External Interfaces/Playlists.cs
+++ b/ModAssistant/Classes/External Interfaces/Playlists.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Web;
 using System.Windows;
 using static ModAssistant.Http;
 
@@ -34,14 +33,11 @@ namespace ModAssistant.API
 
         public static async Task<string> Get(Uri url)
         {
-            string filename = HttpUtility.UrlDecode(url.Segments.Last());
-            string absolutePath = Path.Combine(BeatSaberPath, PlaylistsFolder, filename);
             try
             {
                 CreatePlaylistsFolder();
-                await Utils.DownloadAsset(url.ToString(), PlaylistsFolder, filename);
-
-                return absolutePath;
+                string filename = await Utils.DownloadAsset(url.ToString(), PlaylistsFolder, preferContentDisposition: true);
+                return Path.Combine(BeatSaberPath, PlaylistsFolder, filename);
             }
             catch
             {

--- a/ModAssistant/Classes/Updater.cs
+++ b/ModAssistant/Classes/Updater.cs
@@ -77,7 +77,7 @@ namespace ModAssistant
 
                 File.Move(Utils.ExePath, OldExe);
 
-                await Utils.Download(DownloadLink, NewExe);
+                await Utils.Download(DownloadLink, "", NewExe);
                 RunNew();
             }
         }


### PR DESCRIPTION
When downloading playlists (and previously zips) from beatsaver the last url segment is not always the best name for the downloaded file. BeatSaver provides a header with both of these that suggests a name for the downloaded file. In the case of maps this is "{map key} ({song name} - {artist name}).zip" and for playlists it is "BeatSaver - {playlist name}.bplist"

This PR will prefer the server's suggestion for **playlists** which should result in the top file being created:
![image](https://user-images.githubusercontent.com/534069/143227857-5ed12ce8-ee2a-42ce-acb5-e14f3443a004.png)

This is not intended to alter anything but the naming