### PR TITLE
Update void check

### DIFF
--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -387,12 +387,22 @@ namespace ModAssistant
         {
             string directory = App.BeatSaberInstallDirectory;
             string pluginsDirectory = Path.Combine(directory, "Beat Saber_Data", "Plugins");
-
+            string pluginsx86Directory = Path.Combine(directory, "Beat Saber_Data", "Plugins", "x86_64");
+            
+            if(File.Exists(Path.Combine(pluginsx86Directory, "steam_api64.dll")))
+            {
+                if(Utils.CalculateMD5(Path.Combine(pluginsx86Directory, "steam_api64.dll")) == "0276b122929fcd74fee949142d65f6a2")
+                {
+                    return true;
+                }
+            }
             if (File.Exists(Path.Combine(directory, "IGG-GAMES.COM.url")) ||
                 File.Exists(Path.Combine(directory, "SmartSteamEmu.ini")) ||
                 File.Exists(Path.Combine(directory, "GAMESTORRENT.CO.url")) ||
                 File.Exists(Path.Combine(pluginsDirectory, "BSteam crack.dll")) ||
                 File.Exists(Path.Combine(pluginsDirectory, "HUHUVR_steam_api64.dll")) ||
+                File.Exists(Path.Combine(pluginsx86Directory, "171VR_提供破解补丁.txt")) ||
+                File.Exists(Path.Combine(pluginsx86Directory, "171VR_最全VR游戏下载网站.html")) ||
                 Directory.GetFiles(pluginsDirectory, "*.ini", SearchOption.TopDirectoryOnly).Where(x => Path.GetFileName(x) != "desktop.ini").Any())
                 return true;
             return false;


### PR DESCRIPTION
I recently found someone selling pirated copies in the community, so I wanted to update the piracy detection.
After getting the pirated file, I used FreeFileSync to compare the file contents with the original game and here are the differences.
![](https://s.wgzeyu.com/img/bs/QQ%E6%88%AA%E5%9B%BE20220307053722.png)
(the following filtering was used)
![](https://s.wgzeyu.com/img/bs/QQ%E6%88%AA%E5%9B%BE20220307085116.png)