### PR TITLE
Include query params in oneclick playlist requests

### DIFF
--- a/ModAssistant/Classes/External Interfaces/Playlists.cs
+++ b/ModAssistant/Classes/External Interfaces/Playlists.cs
@@ -24,7 +24,7 @@ namespace ModAssistant.API
             switch (uri.Host)
             {
                 case "playlist":
-                    Uri url = new Uri($"{uri.LocalPath.Trim('/')}");
+                    Uri url = new Uri($"{uri.PathAndQuery.Trim('/')}");
                     string filename = await Get(url);
                     await DownloadFrom(filename);
                     break;


### PR DESCRIPTION
Passes query parameters through from bsplaylist:// url handler
This allows for the creation of signed urls for private playlists