### PR TITLE
Show a warning when trying to install mods for the wrong game version

### DIFF
--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -30,6 +30,11 @@
     <sys:String x:Key="MainWindow:GameUpdateDialog:Line2">Please double check that the correct version is selected at the bottom left corner!</sys:String>
     <sys:String x:Key="MainWindow:NoModSelected">No mod selected!</sys:String>
     <sys:String x:Key="MainWindow:NoModInfoPage">{0} does not have an info page.</sys:String>
+    <sys:String x:Key="MainWindow:GameVersionMismatch" xml:space="preserve">The selected game version ({0}) is different from detected ({1})!
+Installing mismatched Mods may break your game! Do you want to continue?</sys:String>
+    <sys:String x:Key="MainWindow:GameVersionMismatchTitle">Warning: Game Version Mismatch</sys:String>
+    <sys:String x:Key="MainWindow:GameVersionUnknown">Unknown</sys:String>
+
 
     <!-- Intro Page -->
     <sys:String x:Key="Intro:Title">Intro</sys:String>
@@ -120,7 +125,7 @@
         <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://bs.assistant.moe/Donate/">
             donation page
         </Hyperlink>
-        or the 
+        or the
         <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             BSMG Patreon
         </Hyperlink>

--- a/ModAssistant/Localisation/zh.xaml
+++ b/ModAssistant/Localisation/zh.xaml
@@ -30,6 +30,11 @@
     <sys:String x:Key="MainWindow:GameUpdateDialog:Line2">请仔细检查左下角是否选择了正确的游戏版本！</sys:String>
     <sys:String x:Key="MainWindow:NoModSelected">没有选择Mod！</sys:String>
     <sys:String x:Key="MainWindow:NoModInfoPage">{0}没有信息页。</sys:String>
+    <sys:String x:Key="MainWindow:GameVersionMismatch" xml:space="preserve">您选择的游戏版本 {0} 与当前检测到的游戏版本 {1} 不匹配，是否要继续安装Mod？
+警告：继续安装Mod可能会破坏你的游戏，Mod需要匹配游戏版本，否则会出错。</sys:String>
+    <sys:String x:Key="MainWindow:GameVersionMismatchTitle">警告：游戏版本不匹配</sys:String>
+    <sys:String x:Key="MainWindow:GameVersionUnknown">未知</sys:String>
+
 
     <!-- Intro Page -->
     <sys:String x:Key="Intro:Title">简介</sys:String>
@@ -236,7 +241,7 @@
     <sys:String x:Key="OneClick:DoneNotify">OneClick™ 安装完毕</sys:String>
     <sys:String x:Key="OneClick:StartDownloadPlaylist">开始下载歌曲列表</sys:String>
     <sys:String x:Key="OneClick:Done">执行完毕</sys:String>
-    
+
     <!-- Themes Class -->
     <sys:String x:Key="Themes:ThemeNotFound">找不到主题，恢复为默认主题...</sys:String>
     <sys:String x:Key="Themes:ThemeSet">主题设置为{0}.</sys:String>

--- a/ModAssistant/MainWindow.xaml.cs
+++ b/ModAssistant/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ namespace ModAssistant
         public static bool ModsOpened = false;
         public static bool ModsLoading = false;
         public static string GameVersion;
+        public static string GameVersionDetected;  // the game version detected from the game files, will be empty if not known by BeatMods
         public static string GameVersionOverride;
         public TaskCompletionSource<bool> VersionLoadStatus = new TaskCompletionSource<bool>();
 
@@ -118,6 +119,7 @@ namespace ModAssistant
                 var aliases = await Utils.GetAliasDictionary();
 
                 string version = await Utils.GetVersion();
+                GameVersionDetected = version;
                 if (!versions.Contains(version) && CheckAliases(versions, aliases, version) == string.Empty)
                 {
                     versions.Insert(0, version);
@@ -270,7 +272,29 @@ namespace ModAssistant
 
         private void InstallButton_Click(object sender, RoutedEventArgs e)
         {
-            Mods.Instance.InstallMods();
+            if (string.IsNullOrEmpty(GameVersionOverride) // game version not listed in aliases at all, i.e. not a known version by BeatMods
+                && GameVersion != GameVersionDetected) // and the user manually selected a version
+            {
+
+                string detected = string.IsNullOrEmpty(GameVersionDetected)
+                    ? (string)Application.Current.FindResource("MainWindow:GameVersionUnknown")
+                    : GameVersionDetected;
+
+                // show a waring about the version mismatch
+                var result = MessageBox.Show(
+                    string.Format((string)Application.Current.FindResource("MainWindow:GameVersionMismatch"), GameVersion, detected),
+                    (string)Application.Current.FindResource("MainWindow:GameVersionMismatchTitle"),
+                    MessageBoxButton.OKCancel);
+
+                if (result == MessageBoxResult.OK)
+                {
+                    Mods.Instance.InstallMods();
+                }
+            }
+            else
+            {
+                Mods.Instance.InstallMods();
+            }
         }
 
         private void InfoButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
If the detected game version is not listed by beatmods, and the user manually selected a game version, show a warning about the mismatch game version when trying to install mods.

This has happened many times before. When there is a new update, before beatmods update their version list, some users may attempt to manually select the previous moddable version which results in a broken game. Especially during the unity update.

Some users even thought they could downgrade the game by simply selecting an older game version in ModAssistant.