### PR TITLE
Add `Libs/Native` to search folders

### DIFF
--- a/ModAssistant/Pages/Mods.xaml.cs
+++ b/ModAssistant/Pages/Mods.xaml.cs
@@ -186,8 +186,10 @@ namespace ModAssistant.Pages
             GetBSIPAVersion();
             CheckInstallDir("IPA/Pending/Plugins");
             CheckInstallDir("IPA/Pending/Libs");
+            CheckInstallDir("IPA/Pending/Libs/Native");
             CheckInstallDir("Plugins");
             CheckInstallDir("Libs");
+            CheckInstallDir("Libs/Native");
         }
 
         public async Task GetAllMods()


### PR DESCRIPTION
This just adds `Libs/Native` and `IPA/Pending/Libs/Native` to the folders searched for installed mods so mods with native libraries (e.g. LookupID) are recognized properly.